### PR TITLE
feat: implement multi-cluster support for worker dispatch and authent…

### DIFF
--- a/cmd/orchestrator/main.go
+++ b/cmd/orchestrator/main.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
-	"time"
 
 	"github.com/mimir-aip/mimir-aip-go/pkg/api"
 	"github.com/mimir-aip/mimir-aip-go/pkg/config"
@@ -16,7 +15,6 @@ import (
 	mcpserver "github.com/mimir-aip/mimir-aip-go/pkg/mcp"
 	"github.com/mimir-aip/mimir-aip-go/pkg/metadatastore"
 	"github.com/mimir-aip/mimir-aip-go/pkg/mlmodel"
-	"github.com/mimir-aip/mimir-aip-go/pkg/models"
 	"github.com/mimir-aip/mimir-aip-go/pkg/ontology"
 	"github.com/mimir-aip/mimir-aip-go/pkg/pipeline"
 	"github.com/mimir-aip/mimir-aip-go/pkg/plugins"
@@ -44,19 +42,33 @@ func main() {
 
 	log.Println("Initialized in-memory job queue")
 
-	// Initialize Kubernetes client
-	k8sClient, err := k8s.NewClient(k8s.ClientConfig{
-		Namespace:          cfg.WorkerNamespace,
-		OrchestratorURL:    cfg.OrchestratorURL,
-		ServiceAccountName: cfg.WorkerServiceAccount,
-		CPULimit:           cfg.WorkerCPULimit,
-		MemoryLimit:        cfg.WorkerMemoryLimit,
-	})
-	if err != nil {
-		log.Fatalf("Failed to initialize Kubernetes client: %v", err)
+	// Initialize Kubernetes cluster pool
+	// When CLUSTER_CONFIG_FILE is set, load multi-cluster config; otherwise use a single
+	// in-cluster pool that preserves the existing single-cluster behaviour exactly.
+	var clusterPool *k8s.ClusterPool
+	if cfg.ClusterConfigFile != "" {
+		clusterPool, err = k8s.LoadClusterPool(cfg.ClusterConfigFile, cfg.WorkerAuthToken)
+		if err != nil {
+			log.Fatalf("Failed to load cluster config from %q: %v", cfg.ClusterConfigFile, err)
+		}
+		log.Printf("Loaded %d cluster(s) from %s", clusterPool.Len(), cfg.ClusterConfigFile)
+	} else {
+		// Single in-cluster (backward-compatible default)
+		clusterPool, err = k8s.NewClusterPool([]k8s.ClusterConfig{
+			{
+				Name:            "primary",
+				Kubeconfig:      "",
+				Namespace:       cfg.WorkerNamespace,
+				OrchestratorURL: cfg.OrchestratorURL,
+				MaxWorkers:      cfg.MaxWorkers,
+				ServiceAccount:  cfg.WorkerServiceAccount,
+			},
+		}, cfg.WorkerAuthToken)
+		if err != nil {
+			log.Fatalf("Failed to initialize Kubernetes client: %v", err)
+		}
+		log.Println("Connected to Kubernetes cluster (single in-cluster mode)")
 	}
-
-	log.Println("Connected to Kubernetes cluster")
 
 	// Initialize storage
 	storageDir := cfg.Environment + "-data"
@@ -129,7 +141,7 @@ func main() {
 	log.Println("Started job scheduler")
 
 	// Start API server in a goroutine
-	server := api.NewServer(q, cfg.Port)
+	server := api.NewServer(q, cfg.Port, cfg.WorkerAuthToken)
 
 	// Register project handlers
 	projectHandler := api.NewProjectHandler(projectService)
@@ -203,7 +215,7 @@ func main() {
 	}()
 
 	// Start worker spawner
-	spawner := NewWorkerSpawner(q, k8sClient, cfg)
+	spawner := NewWorkerSpawner(q, clusterPool, cfg)
 	go spawner.Run()
 
 	log.Println("Orchestrator started successfully")
@@ -216,110 +228,3 @@ func main() {
 	log.Println("Shutting down orchestrator...")
 }
 
-// WorkerSpawner manages worker job creation and monitoring
-type WorkerSpawner struct {
-	queue     *queue.Queue
-	k8sClient *k8s.Client
-	config    *config.Config
-}
-
-// NewWorkerSpawner creates a new worker spawner
-func NewWorkerSpawner(q *queue.Queue, k8sClient *k8s.Client, cfg *config.Config) *WorkerSpawner {
-	return &WorkerSpawner{
-		queue:     q,
-		k8sClient: k8sClient,
-		config:    cfg,
-	}
-}
-
-// Run starts the worker spawning loop
-func (ws *WorkerSpawner) Run() {
-	ticker := time.NewTicker(5 * time.Second)
-	defer ticker.Stop()
-
-	for range ticker.C {
-		ws.processQueue()
-	}
-}
-
-// processQueue checks the queue and spawns workers as needed
-func (ws *WorkerSpawner) processQueue() {
-	queueLength, err := ws.queue.QueueLength()
-	if err != nil {
-		log.Printf("Error getting queue length: %v", err)
-		return
-	}
-
-	if queueLength == 0 {
-		return
-	}
-
-	activeWorkers, err := ws.k8sClient.GetActiveWorkerCount()
-	if err != nil {
-		log.Printf("Error getting active worker count: %v", err)
-		return
-	}
-
-	// Check if we should spawn a worker
-	if !ws.shouldSpawnWorker(queueLength, int64(activeWorkers)) {
-		log.Printf("Scaling decision: queue=%d, active=%d, min=%d, max=%d, threshold=%d - NOT spawning (limit reached or queue too small)",
-			queueLength, activeWorkers, ws.config.MinWorkers, ws.config.MaxWorkers, ws.config.QueueThreshold)
-		return
-	}
-
-	log.Printf("Scaling decision: queue=%d, active=%d, min=%d, max=%d, threshold=%d - SPAWNING worker",
-		queueLength, activeWorkers, ws.config.MinWorkers, ws.config.MaxWorkers, ws.config.QueueThreshold)
-
-	// Dequeue a work task
-	task, err := ws.queue.Dequeue()
-	if err != nil {
-		log.Printf("Error dequeuing work task: %v", err)
-		return
-	}
-
-	if task == nil {
-		return // No tasks available
-	}
-
-	// Update task status to scheduled
-	if err := ws.queue.UpdateWorkTaskStatus(task.ID, models.WorkTaskStatusScheduled, ""); err != nil {
-		log.Printf("Error updating work task status: %v", err)
-		return
-	}
-
-	// Create worker job
-	if err := ws.k8sClient.CreateWorkerJob(task, ws.config.WorkerImage); err != nil {
-		log.Printf("Error creating worker job: %v", err)
-		// Update task status to failed
-		ws.queue.UpdateWorkTaskStatus(task.ID, models.WorkTaskStatusFailed, err.Error())
-		return
-	}
-
-	log.Printf("Spawned worker for task %s (type: %s)", task.ID, task.Type)
-
-	// Update task status to spawned
-	task.KubernetesJobName = "worker-task-" + task.ID
-	if err := ws.queue.UpdateWorkTaskStatus(task.ID, models.WorkTaskStatusSpawned, ""); err != nil {
-		log.Printf("Error updating work task status: %v", err)
-	}
-}
-
-// shouldSpawnWorker determines if a new worker should be spawned
-func (ws *WorkerSpawner) shouldSpawnWorker(queueLength, activeWorkers int64) bool {
-	// Always maintain minimum workers
-	if activeWorkers < int64(ws.config.MinWorkers) && queueLength > 0 {
-		return true
-	}
-
-	// Don't exceed max workers
-	if activeWorkers >= int64(ws.config.MaxWorkers) {
-		return false
-	}
-
-	// Scale based on queue depth
-	if queueLength > int64(ws.config.QueueThreshold) {
-		return true
-	}
-
-	return false
-}

--- a/cmd/orchestrator/spawner.go
+++ b/cmd/orchestrator/spawner.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"log"
+	"time"
+
+	"github.com/mimir-aip/mimir-aip-go/pkg/config"
+	"github.com/mimir-aip/mimir-aip-go/pkg/k8s"
+	"github.com/mimir-aip/mimir-aip-go/pkg/models"
+	"github.com/mimir-aip/mimir-aip-go/pkg/queue"
+)
+
+// WorkerSpawner manages worker job creation across a pool of Kubernetes clusters.
+type WorkerSpawner struct {
+	queue  *queue.Queue
+	pool   *k8s.ClusterPool
+	config *config.Config
+}
+
+// NewWorkerSpawner creates a new WorkerSpawner backed by a ClusterPool.
+func NewWorkerSpawner(q *queue.Queue, pool *k8s.ClusterPool, cfg *config.Config) *WorkerSpawner {
+	return &WorkerSpawner{
+		queue:  q,
+		pool:   pool,
+		config: cfg,
+	}
+}
+
+// Run starts the worker spawning loop.
+func (ws *WorkerSpawner) Run() {
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		ws.processQueue()
+	}
+}
+
+// processQueue checks the queue and spawns workers across the cluster pool as needed.
+func (ws *WorkerSpawner) processQueue() {
+	queueLength, err := ws.queue.QueueLength()
+	if err != nil {
+		log.Printf("Error getting queue length: %v", err)
+		return
+	}
+
+	if queueLength == 0 {
+		return
+	}
+
+	// Query active worker counts per cluster
+	counts := ws.pool.ActiveWorkerCounts()
+	totalActive := sumCounts(counts)
+	totalCapacity := ws.pool.TotalCapacity()
+
+	if !ws.shouldSpawnWorker(queueLength, int64(totalActive), int64(totalCapacity)) {
+		log.Printf("Scaling decision: queue=%d, active=%d, capacity=%d, min=%d, threshold=%d - NOT spawning",
+			queueLength, totalActive, totalCapacity, ws.config.MinWorkers, ws.config.QueueThreshold)
+		return
+	}
+
+	log.Printf("Scaling decision: queue=%d, active=%d, capacity=%d - SPAWNING worker",
+		queueLength, totalActive, totalCapacity)
+
+	// Dequeue a work task
+	task, err := ws.queue.Dequeue()
+	if err != nil {
+		log.Printf("Error dequeuing work task: %v", err)
+		return
+	}
+	if task == nil {
+		return
+	}
+
+	// Select the target cluster (preferred affinity → burst order)
+	entry := ws.pool.SelectCluster(counts, task.TaskSpec.PreferredCluster)
+	if entry == nil {
+		log.Printf("No cluster has available capacity; re-queuing task %s", task.ID)
+		_ = ws.queue.UpdateWorkTaskStatus(task.ID, models.WorkTaskStatusQueued, "")
+		return
+	}
+
+	task.ClusterName = entry.Config.Name
+
+	// Update task status to scheduled
+	if err := ws.queue.UpdateWorkTaskStatus(task.ID, models.WorkTaskStatusScheduled, ""); err != nil {
+		log.Printf("Error updating work task status: %v", err)
+		return
+	}
+
+	// Create worker job on the selected cluster
+	if err := entry.Client.CreateWorkerJob(task, ws.config.WorkerImage, entry.Config.OrchestratorURL); err != nil {
+		log.Printf("Error creating worker job on cluster %q: %v", entry.Config.Name, err)
+		ws.queue.UpdateWorkTaskStatus(task.ID, models.WorkTaskStatusFailed, err.Error())
+		return
+	}
+
+	log.Printf("Spawned worker for task %s (type: %s) on cluster %q", task.ID, task.Type, entry.Config.Name)
+
+	task.KubernetesJobName = "worker-task-" + task.ID
+	if err := ws.queue.UpdateWorkTaskStatus(task.ID, models.WorkTaskStatusSpawned, ""); err != nil {
+		log.Printf("Error updating work task status to spawned: %v", err)
+	}
+}
+
+// shouldSpawnWorker determines if a new worker should be spawned.
+func (ws *WorkerSpawner) shouldSpawnWorker(queueLength, totalActive, totalCapacity int64) bool {
+	// Always maintain minimum workers while there is work to do
+	if totalActive < int64(ws.config.MinWorkers) && queueLength > 0 {
+		return true
+	}
+
+	// Don't exceed total capacity across all clusters
+	if totalActive >= totalCapacity {
+		return false
+	}
+
+	// Scale based on queue depth threshold
+	if queueLength > int64(ws.config.QueueThreshold) {
+		return true
+	}
+
+	return false
+}
+
+// sumCounts returns the sum of all values in a cluster-count map.
+func sumCounts(counts map[string]int) int {
+	total := 0
+	for _, v := range counts {
+		total += v
+	}
+	return total
+}

--- a/helm/mimir-aip/templates/cluster-config.yaml
+++ b/helm/mimir-aip/templates/cluster-config.yaml
@@ -1,0 +1,58 @@
+{{- if .Values.workerAuthToken }}
+---
+# Secret: shared bearer token for worker→orchestrator authentication.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "mimir-aip.fullname" . }}-worker-auth
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mimir-aip.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  token: {{ .Values.workerAuthToken | quote }}
+{{- end }}
+{{- if .Values.additionalClusters }}
+---
+# ConfigMap: cluster pool configuration file consumed by the orchestrator.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "mimir-aip.fullname" . }}-clusters
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mimir-aip.labels" . | nindent 4 }}
+data:
+  clusters.yaml: |
+    clusters:
+      # Primary in-cluster cluster (always first)
+      - name: primary
+        kubeconfig: ""
+        namespace: {{ include "mimir-aip.workerNamespace" . }}
+        orchestratorURL: http://{{ include "mimir-aip.fullname" . }}-orchestrator:{{ .Values.orchestrator.port }}
+        maxWorkers: {{ .Values.orchestrator.maxWorkers }}
+        serviceAccount: {{ .Values.orchestrator.workerServiceAccount }}
+      {{- range .Values.additionalClusters }}
+      - name: {{ .name | quote }}
+        kubeconfig: {{ printf "/etc/mimir/kubeconfigs/%s.yaml" .name | quote }}
+        namespace: {{ .namespace | quote }}
+        orchestratorURL: {{ .orchestratorURL | quote }}
+        maxWorkers: {{ .maxWorkers }}
+        serviceAccount: {{ .serviceAccount | quote }}
+      {{- end }}
+---
+# Secret: remote kubeconfig files, one per additional cluster.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "mimir-aip.fullname" . }}-kubeconfigs
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mimir-aip.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- range .Values.additionalClusters }}
+  {{ printf "%s.yaml" .name }}: |
+    {{- .kubeconfig | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm/mimir-aip/templates/orchestrator.yaml
+++ b/helm/mimir-aip/templates/orchestrator.yaml
@@ -33,10 +33,31 @@ spec:
         envFrom:
         - configMapRef:
             name: {{ include "mimir-aip.fullname" . }}-config
-        {{- if .Values.orchestrator.persistence.enabled }}
+        env:
+        {{- if .Values.workerAuthToken }}
+        - name: WORKER_AUTH_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "mimir-aip.fullname" . }}-worker-auth
+              key: token
+        {{- end }}
+        {{- if .Values.additionalClusters }}
+        - name: CLUSTER_CONFIG_FILE
+          value: /etc/mimir/clusters.yaml
+        {{- end }}
         volumeMounts:
+        {{- if .Values.orchestrator.persistence.enabled }}
         - name: data
           mountPath: {{ .Values.orchestrator.storageDir }}
+        {{- end }}
+        {{- if .Values.additionalClusters }}
+        - name: cluster-config
+          mountPath: /etc/mimir/clusters.yaml
+          subPath: clusters.yaml
+          readOnly: true
+        - name: kubeconfigs
+          mountPath: /etc/mimir/kubeconfigs
+          readOnly: true
         {{- end }}
         resources:
           {{- toYaml .Values.orchestrator.resources | nindent 10 }}
@@ -52,11 +73,19 @@ spec:
             port: http
           initialDelaySeconds: 5
           periodSeconds: 5
-      {{- if .Values.orchestrator.persistence.enabled }}
       volumes:
+      {{- if .Values.orchestrator.persistence.enabled }}
       - name: data
         persistentVolumeClaim:
           claimName: {{ include "mimir-aip.fullname" . }}-data
+      {{- end }}
+      {{- if .Values.additionalClusters }}
+      - name: cluster-config
+        configMap:
+          name: {{ include "mimir-aip.fullname" . }}-clusters
+      - name: kubeconfigs
+        secret:
+          secretName: {{ include "mimir-aip.fullname" . }}-kubeconfigs
       {{- end }}
 ---
 apiVersion: v1

--- a/helm/mimir-aip/values.yaml
+++ b/helm/mimir-aip/values.yaml
@@ -63,3 +63,26 @@ networkPolicy:
 rbac:
   # Set to true to create ServiceAccounts, ClusterRole, and ClusterRoleBinding
   create: true
+
+# -- Worker auth token
+# When set, workers must present this value as "Authorization: Bearer <token>"
+# when calling back to the orchestrator on /api/worktasks/* paths.
+# Leave empty to disable authentication on those paths (default).
+workerAuthToken: ""
+
+# -- Additional remote Kubernetes clusters for worker dispatch.
+# The primary in-cluster cluster is always implicit and does not need to be listed here.
+# Workers overflow to these clusters in declaration order once the primary is at capacity.
+#
+# Example:
+# additionalClusters:
+#   - name: site-b
+#     orchestratorURL: http://192.168.10.5:8080   # orchestrator IP as seen from site-b nodes
+#     maxWorkers: 50
+#     namespace: mimir-aip
+#     serviceAccount: mimir-worker
+#     kubeconfig: |
+#       apiVersion: v1
+#       kind: Config
+#       ...
+additionalClusters: []

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -14,29 +14,49 @@ import (
 
 // Server provides HTTP API endpoints
 type Server struct {
-	queue *queue.Queue
-	port  string
-	mux   *http.ServeMux
+	queue           *queue.Queue
+	port            string
+	mux             *http.ServeMux
+	workerAuthToken string // if non-empty, required as Bearer token on /api/worktasks/* paths
 }
 
-// NewServer creates a new API server
-func NewServer(q *queue.Queue, port string) *Server {
+// NewServer creates a new API server.
+// workerAuthToken gates the worker-facing /api/worktasks/* paths when non-empty.
+func NewServer(q *queue.Queue, port string, workerAuthToken string) *Server {
 	s := &Server{
-		queue: q,
-		port:  port,
-		mux:   http.NewServeMux(),
+		queue:           q,
+		port:            port,
+		mux:             http.NewServeMux(),
+		workerAuthToken: workerAuthToken,
 	}
 
 	s.registerRoutes()
 	return s
 }
 
+// workerAuthMiddleware returns an http.HandlerFunc that validates the Authorization: Bearer
+// header when a workerAuthToken is configured. Requests without a valid token receive 401.
+func (s *Server) workerAuthMiddleware(next http.HandlerFunc) http.HandlerFunc {
+	if s.workerAuthToken == "" {
+		return next
+	}
+	return func(w http.ResponseWriter, r *http.Request) {
+		const prefix = "Bearer "
+		auth := r.Header.Get("Authorization")
+		if len(auth) <= len(prefix) || auth[:len(prefix)] != prefix || auth[len(prefix):] != s.workerAuthToken {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+		next(w, r)
+	}
+}
+
 // registerRoutes sets up the HTTP routes
 func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("/health", s.handleHealth)
 	s.mux.HandleFunc("/ready", s.handleReady)
-	s.mux.HandleFunc("/api/worktasks", s.handleWorkTasks)
-	s.mux.HandleFunc("/api/worktasks/", s.handleWorkTaskByID)
+	s.mux.HandleFunc("/api/worktasks", s.workerAuthMiddleware(s.handleWorkTasks))
+	s.mux.HandleFunc("/api/worktasks/", s.workerAuthMiddleware(s.handleWorkTaskByID))
 }
 
 // RegisterHandler adds a custom handler to the server

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -22,6 +22,9 @@ type Config struct {
 	WorkerImage          string
 	WorkerCPULimit       string
 	WorkerMemoryLimit    string
+	// Multi-cluster dispatch
+	ClusterConfigFile string // path to YAML cluster config; empty = single in-cluster behaviour
+	WorkerAuthToken   string // shared Bearer token for /api/worktasks/* paths; empty = disabled
 }
 
 // LoadConfig loads configuration from environment variables
@@ -42,6 +45,8 @@ func LoadConfig() (*Config, error) {
 		WorkerImage:          getEnv("WORKER_IMAGE", "mimir-aip/worker:latest"),
 		WorkerCPULimit:       getEnv("WORKER_CPU_LIMIT", "2000m"),
 		WorkerMemoryLimit:    getEnv("WORKER_MEMORY_LIMIT", "4Gi"),
+		ClusterConfigFile:    getEnv("CLUSTER_CONFIG_FILE", ""),
+		WorkerAuthToken:      getEnv("WORKER_AUTH_TOKEN", ""),
 	}
 
 	return config, nil

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -24,6 +24,7 @@ type ClientConfig struct {
 	ServiceAccountName string
 	CPULimit           string
 	MemoryLimit        string
+	WorkerAuthToken    string // injected as WORKER_AUTH_TOKEN env var in spawned Jobs; empty = disabled
 }
 
 // Client provides Kubernetes API operations
@@ -34,17 +35,24 @@ type Client struct {
 	serviceAccountName string
 	cpuLimit           string
 	memoryLimit        string
+	workerAuthToken    string
 	ctx                context.Context
 }
 
-// NewClient creates a new Kubernetes client
+// NewClient creates a new Kubernetes client using in-cluster config or the default kubeconfig.
 func NewClient(cfg ClientConfig) (*Client, error) {
-	config, err := getKubeConfig()
+	return NewClientWithKubeconfig(cfg, "")
+}
+
+// NewClientWithKubeconfig creates a new Kubernetes client with an explicit kubeconfig path.
+// Pass an empty kubeconfigPath to use in-cluster config (falling back to ~/.kube/config).
+func NewClientWithKubeconfig(cfg ClientConfig, kubeconfigPath string) (*Client, error) {
+	restCfg, err := getKubeConfig(kubeconfigPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get kubernetes config: %w", err)
 	}
 
-	clientset, err := kubernetes.NewForConfig(config)
+	clientset, err := kubernetes.NewForConfig(restCfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create kubernetes clientset: %w", err)
 	}
@@ -72,12 +80,23 @@ func NewClient(cfg ClientConfig) (*Client, error) {
 		serviceAccountName: cfg.ServiceAccountName,
 		cpuLimit:           cfg.CPULimit,
 		memoryLimit:        cfg.MemoryLimit,
+		workerAuthToken:    cfg.WorkerAuthToken,
 		ctx:                context.Background(),
 	}, nil
 }
 
-// getKubeConfig returns the Kubernetes configuration
-func getKubeConfig() (*rest.Config, error) {
+// getKubeConfig returns the Kubernetes REST configuration.
+// If kubeconfigPath is non-empty it is used directly; otherwise in-cluster config is tried
+// first, then the default ~/.kube/config.
+func getKubeConfig(kubeconfigPath string) (*rest.Config, error) {
+	if kubeconfigPath != "" {
+		cfg, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+		if err != nil {
+			return nil, fmt.Errorf("build config from %q: %w", kubeconfigPath, err)
+		}
+		return cfg, nil
+	}
+
 	// Try in-cluster config first
 	config, err := rest.InClusterConfig()
 	if err == nil {
@@ -98,9 +117,15 @@ func getKubeConfig() (*rest.Config, error) {
 	return config, nil
 }
 
-// CreateWorkerJob creates a Kubernetes Job for a worker to execute a work task
-func (c *Client) CreateWorkerJob(task *models.WorkTask, workerImage string) error {
+// CreateWorkerJob creates a Kubernetes Job for a worker to execute a work task.
+// orchestratorURL is the URL the worker will use to call back to the orchestrator;
+// it overrides the URL stored in the client, allowing per-cluster callback addresses.
+func (c *Client) CreateWorkerJob(task *models.WorkTask, workerImage string, orchestratorURL string) error {
 	jobName := fmt.Sprintf("worker-task-%s", task.ID)
+
+	if orchestratorURL == "" {
+		orchestratorURL = c.orchestratorURL
+	}
 
 	// Parse resource requirements
 	cpuRequest := task.ResourceRequirements.CPU
@@ -126,7 +151,15 @@ func (c *Client) CreateWorkerJob(task *models.WorkTask, workerImage string) erro
 	envVars := []corev1.EnvVar{
 		{Name: "WORKTASK_ID", Value: task.ID},
 		{Name: "WORKTASK_TYPE", Value: string(task.Type)},
-		{Name: "ORCHESTRATOR_URL", Value: c.orchestratorURL},
+		{Name: "ORCHESTRATOR_URL", Value: orchestratorURL},
+	}
+
+	// Inject worker auth token if configured
+	if c.workerAuthToken != "" {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  "WORKER_AUTH_TOKEN",
+			Value: c.workerAuthToken,
+		})
 	}
 
 	// Create Job specification

--- a/pkg/k8s/cluster_pool.go
+++ b/pkg/k8s/cluster_pool.go
@@ -1,0 +1,130 @@
+package k8s
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ClusterConfig holds configuration for a single Kubernetes cluster entry.
+type ClusterConfig struct {
+	Name            string `yaml:"name"`
+	Kubeconfig      string `yaml:"kubeconfig"`      // empty = in-cluster
+	Namespace       string `yaml:"namespace"`
+	OrchestratorURL string `yaml:"orchestratorURL"` // URL workers on this cluster use to reach the orchestrator
+	MaxWorkers      int    `yaml:"maxWorkers"`
+	ServiceAccount  string `yaml:"serviceAccount"`
+}
+
+// ClusterEntry pairs a ClusterConfig with its initialised k8s Client.
+type ClusterEntry struct {
+	Config ClusterConfig
+	Client *Client
+}
+
+// ClusterPool manages a prioritised list of Kubernetes clusters for worker dispatch.
+// The primary cluster is always the first entry; additional entries receive overflow.
+type ClusterPool struct {
+	entries   []ClusterEntry
+	authToken string // shared WORKER_AUTH_TOKEN injected into every spawned Job
+}
+
+// clusterConfigFile is the on-disk YAML format for the cluster config file.
+type clusterConfigFile struct {
+	Clusters []ClusterConfig `yaml:"clusters"`
+}
+
+// NewClusterPool creates a ClusterPool from a slice of ClusterConfig entries.
+// authToken is injected as WORKER_AUTH_TOKEN into every Job spawned by any cluster.
+func NewClusterPool(configs []ClusterConfig, authToken string) (*ClusterPool, error) {
+	pool := &ClusterPool{authToken: authToken}
+
+	for _, cfg := range configs {
+		client, err := NewClientWithKubeconfig(ClientConfig{
+			Namespace:          cfg.Namespace,
+			OrchestratorURL:    cfg.OrchestratorURL,
+			ServiceAccountName: cfg.ServiceAccount,
+			WorkerAuthToken:    authToken,
+		}, cfg.Kubeconfig)
+		if err != nil {
+			return nil, fmt.Errorf("cluster %q: %w", cfg.Name, err)
+		}
+		pool.entries = append(pool.entries, ClusterEntry{Config: cfg, Client: client})
+	}
+
+	return pool, nil
+}
+
+// LoadClusterPool reads a YAML cluster config file and returns an initialised ClusterPool.
+func LoadClusterPool(path string, authToken string) (*ClusterPool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read cluster config file %q: %w", path, err)
+	}
+
+	var f clusterConfigFile
+	if err := yaml.Unmarshal(data, &f); err != nil {
+		return nil, fmt.Errorf("parse cluster config file %q: %w", path, err)
+	}
+
+	return NewClusterPool(f.Clusters, authToken)
+}
+
+// ActiveWorkerCounts queries each cluster and returns a map of cluster name -> active worker count.
+// Clusters that fail to respond are counted as 0 so dispatch can still proceed.
+func (p *ClusterPool) ActiveWorkerCounts() map[string]int {
+	counts := make(map[string]int, len(p.entries))
+	for _, e := range p.entries {
+		n, err := e.Client.GetActiveWorkerCount()
+		if err != nil {
+			n = 0
+		}
+		counts[e.Config.Name] = n
+	}
+	return counts
+}
+
+// TotalCapacity returns the sum of MaxWorkers across all cluster entries.
+func (p *ClusterPool) TotalCapacity() int {
+	total := 0
+	for _, e := range p.entries {
+		total += e.Config.MaxWorkers
+	}
+	return total
+}
+
+// SelectCluster returns the best ClusterEntry to receive a new worker job.
+//
+// Strategy (burst / primary-first):
+//  1. If preferred is non-empty and that cluster has headroom, use it.
+//  2. Otherwise iterate entries in declaration order and return the first with
+//     available capacity (counts[name] < entry.MaxWorkers).
+//
+// Returns nil if all clusters are at capacity.
+func (p *ClusterPool) SelectCluster(counts map[string]int, preferred string) *ClusterEntry {
+	// Preferred cluster override
+	if preferred != "" {
+		for i := range p.entries {
+			e := &p.entries[i]
+			if e.Config.Name == preferred && counts[e.Config.Name] < e.Config.MaxWorkers {
+				return e
+			}
+		}
+	}
+
+	// Burst: first cluster with headroom
+	for i := range p.entries {
+		e := &p.entries[i]
+		if counts[e.Config.Name] < e.Config.MaxWorkers {
+			return e
+		}
+	}
+
+	return nil
+}
+
+// Len returns the number of cluster entries in the pool.
+func (p *ClusterPool) Len() int {
+	return len(p.entries)
+}

--- a/pkg/k8s/cluster_pool_test.go
+++ b/pkg/k8s/cluster_pool_test.go
@@ -1,0 +1,116 @@
+package k8s
+
+import (
+	"testing"
+)
+
+// mockClusterPool creates a ClusterPool with pre-built entries and no real k8s clients,
+// allowing SelectCluster and TotalCapacity to be unit-tested without a live cluster.
+func mockPool(entries []ClusterEntry) *ClusterPool {
+	return &ClusterPool{entries: entries}
+}
+
+func entry(name string, maxWorkers int) ClusterEntry {
+	return ClusterEntry{
+		Config: ClusterConfig{Name: name, MaxWorkers: maxWorkers},
+		Client: nil, // not used by SelectCluster / TotalCapacity
+	}
+}
+
+// TestSelectCluster_BurstOrder verifies that the first cluster with headroom is chosen.
+func TestSelectCluster_BurstOrder(t *testing.T) {
+	pool := mockPool([]ClusterEntry{
+		entry("primary", 2),
+		entry("site-b", 5),
+	})
+
+	// primary full, site-b has headroom
+	counts := map[string]int{"primary": 2, "site-b": 3}
+	got := pool.SelectCluster(counts, "")
+	if got == nil {
+		t.Fatal("expected a cluster entry, got nil")
+	}
+	if got.Config.Name != "site-b" {
+		t.Errorf("expected site-b, got %q", got.Config.Name)
+	}
+}
+
+// TestSelectCluster_PrimaryFirst verifies that the primary cluster is preferred when it has headroom.
+func TestSelectCluster_PrimaryFirst(t *testing.T) {
+	pool := mockPool([]ClusterEntry{
+		entry("primary", 5),
+		entry("site-b", 5),
+	})
+
+	counts := map[string]int{"primary": 2, "site-b": 0}
+	got := pool.SelectCluster(counts, "")
+	if got == nil {
+		t.Fatal("expected a cluster entry, got nil")
+	}
+	if got.Config.Name != "primary" {
+		t.Errorf("expected primary (first with headroom), got %q", got.Config.Name)
+	}
+}
+
+// TestSelectCluster_PreferredCluster verifies that an explicit preferred cluster is honoured
+// when it has available capacity.
+func TestSelectCluster_PreferredCluster(t *testing.T) {
+	pool := mockPool([]ClusterEntry{
+		entry("primary", 10),
+		entry("gpu-cluster", 4),
+	})
+
+	counts := map[string]int{"primary": 0, "gpu-cluster": 2}
+	got := pool.SelectCluster(counts, "gpu-cluster")
+	if got == nil {
+		t.Fatal("expected a cluster entry, got nil")
+	}
+	if got.Config.Name != "gpu-cluster" {
+		t.Errorf("expected gpu-cluster, got %q", got.Config.Name)
+	}
+}
+
+// TestSelectCluster_PreferredFull falls back to burst order when the preferred cluster is at capacity.
+func TestSelectCluster_PreferredFull(t *testing.T) {
+	pool := mockPool([]ClusterEntry{
+		entry("primary", 5),
+		entry("gpu-cluster", 2),
+	})
+
+	// gpu-cluster is full; should fall back to primary
+	counts := map[string]int{"primary": 1, "gpu-cluster": 2}
+	got := pool.SelectCluster(counts, "gpu-cluster")
+	if got == nil {
+		t.Fatal("expected a cluster entry, got nil")
+	}
+	if got.Config.Name != "primary" {
+		t.Errorf("expected primary (fallback burst), got %q", got.Config.Name)
+	}
+}
+
+// TestSelectCluster_AllFull returns nil when every cluster is at capacity.
+func TestSelectCluster_AllFull(t *testing.T) {
+	pool := mockPool([]ClusterEntry{
+		entry("primary", 2),
+		entry("site-b", 3),
+	})
+
+	counts := map[string]int{"primary": 2, "site-b": 3}
+	got := pool.SelectCluster(counts, "")
+	if got != nil {
+		t.Errorf("expected nil when all clusters full, got %q", got.Config.Name)
+	}
+}
+
+// TestTotalCapacity verifies the sum of all cluster maxWorkers.
+func TestTotalCapacity(t *testing.T) {
+	pool := mockPool([]ClusterEntry{
+		entry("primary", 10),
+		entry("site-b", 20),
+		entry("cloud", 5),
+	})
+
+	if cap := pool.TotalCapacity(); cap != 35 {
+		t.Errorf("expected total capacity 35, got %d", cap)
+	}
+}

--- a/pkg/models/worktask.go
+++ b/pkg/models/worktask.go
@@ -42,10 +42,11 @@ type DataAccess struct {
 
 // TaskSpec contains work task-specific parameters
 type TaskSpec struct {
-	PipelineID string                 `json:"pipeline_id,omitempty"`
-	ModelID    string                 `json:"model_id,omitempty"`
-	ProjectID  string                 `json:"project_id,omitempty"`
-	Parameters map[string]interface{} `json:"parameters"`
+	PipelineID       string                 `json:"pipeline_id,omitempty"`
+	ModelID          string                 `json:"model_id,omitempty"`
+	ProjectID        string                 `json:"project_id,omitempty"`
+	Parameters       map[string]interface{} `json:"parameters"`
+	PreferredCluster string                 `json:"preferred_cluster,omitempty"` // optional cluster affinity; empty = auto
 }
 
 // WorkTask represents an infrastructure work unit to be executed by a worker
@@ -63,6 +64,7 @@ type WorkTask struct {
 	DataAccess           DataAccess           `json:"data_access"`
 	ErrorMessage         string               `json:"error_message,omitempty"`
 	KubernetesJobName    string               `json:"kubernetes_job_name,omitempty"`
+	ClusterName          string               `json:"cluster_name,omitempty"` // cluster this task was dispatched to
 }
 
 // WorkTaskSubmissionRequest represents a request to submit a new work task


### PR DESCRIPTION
…ication(WorkerAuthToken used for primarily remote worker nodes, additionally existing URL params now work for remote workers enabling scaling across multiple clusers[currently implemented as spillover but in future I might work on some attributes for clusers so that we scale workers to most appropriate cluster given the task type e.g. ml training and inference tasks should newWorkerSpawn in a cluster with available gpu to maximise overall performance of system and efficient resource utilisation)