### PR TITLE
feat: dynamic storage plugin loading via Git repositories

### DIFF
--- a/cmd/orchestrator/Dockerfile
+++ b/cmd/orchestrator/Dockerfile
@@ -14,26 +14,35 @@ COPY . .
 # Use -trimpath to ensure reproducible builds for plugin compatibility
 RUN CGO_ENABLED=1 GOOS=linux go build -trimpath -ldflags="-s -w" -o /app/orchestrator ./cmd/orchestrator
 
-# Runtime stage - smaller base image with just what we need
-FROM debian:bookworm-slim
+# Runtime stage — based on the full Go image so that dynamic storage plugins
+# can be compiled at runtime via go build -buildmode=plugin.
+# The Go toolchain, gcc (via debian base), and git are all required.
+FROM golang:1.25
 
-# Install runtime dependencies
+# Install git for cloning plugin repositories
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends ca-certificates git && \
+    apt-get install -y --no-install-recommends git && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
-# Copy built binary from builder
+# Copy the pre-built orchestrator binary
 COPY --from=builder /app/orchestrator .
 
-# Copy source code (needed for potential plugin compilation at runtime)
+# Copy the host module files and source — the dynamic plugin loader compiles
+# external plugins inside /app using these files, so the plugin's code is built
+# against the exact same module the orchestrator was compiled from.
 COPY --from=builder /app/go.mod /app/go.sum ./
 COPY --from=builder /app/pkg ./pkg
 COPY --from=builder /app/cmd ./cmd
 
-# Expose port
+# Pre-warm the module cache so the first plugin install does not require a
+# full go mod download. This does not add new dependencies.
+RUN go mod download
+
+# Directories for compiled .so cache and temporary git clones
+RUN mkdir -p /app/storage-plugins /tmp/sp-temp
+
 EXPOSE 8080
 
-# Run the orchestrator
 CMD ["./orchestrator"]

--- a/cmd/orchestrator/main.go
+++ b/cmd/orchestrator/main.go
@@ -108,7 +108,7 @@ func main() {
 	// Initialize storage service
 	storageService := storage.NewService(store)
 
-	// Register all storage plugins
+	// Register all built-in storage plugins
 	storageService.RegisterPlugin("filesystem", storageplugins.NewFilesystemPlugin())
 	storageService.RegisterPlugin("postgresql", storageplugins.NewPostgresPlugin())
 	storageService.RegisterPlugin("mysql", storageplugins.NewMySQLPlugin())
@@ -117,6 +117,23 @@ func main() {
 	storageService.RegisterPlugin("redis", storageplugins.NewRedisPlugin())
 	storageService.RegisterPlugin("elasticsearch", storageplugins.NewElasticsearchPlugin())
 	storageService.RegisterPlugin("neo4j", storageplugins.NewNeo4jPlugin())
+
+	// Initialise dynamic storage plugin loader.
+	// STORAGE_PLUGIN_DIR overrides the default cache location.
+	storagePluginDir := os.Getenv("STORAGE_PLUGIN_DIR")
+	if storagePluginDir == "" {
+		storagePluginDir = "/app/storage-plugins"
+	}
+	pluginLoader, err := storage.NewPluginLoader("/app", storagePluginDir, tempDir)
+	if err != nil {
+		log.Printf("Warning: failed to initialise dynamic storage plugin loader: %v — external storage plugins will not be available", err)
+	} else {
+		storageService.SetPluginLoader(pluginLoader)
+		if loadErr := storageService.LoadInstalledExternalPlugins(); loadErr != nil {
+			log.Printf("Warning: some external storage plugins failed to reload: %v", loadErr)
+		}
+		log.Println("Dynamic storage plugin loader ready")
+	}
 
 	// Initialize ontology and extraction services
 	ontologyService := ontology.NewService(store)
@@ -179,6 +196,11 @@ func main() {
 	server.RegisterHandler("/api/storage/update", storageHandler.HandleStorageUpdate)
 	server.RegisterHandler("/api/storage/delete", storageHandler.HandleStorageDelete)
 	server.RegisterHandler("/api/storage/health", storageHandler.HandleStorageHealth)
+
+	// Register dynamic storage plugin handlers
+	storagePluginHandler := api.NewStoragePluginHandler(storageService)
+	server.RegisterHandler("/api/storage-plugins", storagePluginHandler.HandleStoragePlugins)
+	server.RegisterHandler("/api/storage-plugins/", storagePluginHandler.HandleStoragePlugin)
 
 	// Register ontology handlers
 	ontologyHandler := api.NewOntologyHandler(ontologyService)

--- a/pkg/api/storage_plugin_handler.go
+++ b/pkg/api/storage_plugin_handler.go
@@ -1,0 +1,116 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/mimir-aip/mimir-aip-go/pkg/models"
+	"github.com/mimir-aip/mimir-aip-go/pkg/storage"
+)
+
+// StoragePluginHandler handles dynamic storage plugin installation/management.
+type StoragePluginHandler struct {
+	service *storage.Service
+}
+
+// NewStoragePluginHandler creates a new StoragePluginHandler.
+func NewStoragePluginHandler(service *storage.Service) *StoragePluginHandler {
+	return &StoragePluginHandler{service: service}
+}
+
+// HandleStoragePlugins handles GET /api/storage-plugins and POST /api/storage-plugins.
+func (h *StoragePluginHandler) HandleStoragePlugins(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		h.handleList(w, r)
+	case http.MethodPost:
+		h.handleInstall(w, r)
+	default:
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+// HandleStoragePlugin handles GET/DELETE /api/storage-plugins/{name}.
+func (h *StoragePluginHandler) HandleStoragePlugin(w http.ResponseWriter, r *http.Request) {
+	name := strings.TrimPrefix(r.URL.Path, "/api/storage-plugins/")
+	name = strings.Trim(name, "/")
+	if name == "" {
+		http.Error(w, "plugin name is required", http.StatusBadRequest)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.handleGet(w, r, name)
+	case http.MethodDelete:
+		h.handleUninstall(w, r, name)
+	default:
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (h *StoragePluginHandler) handleList(w http.ResponseWriter, r *http.Request) {
+	plugins, err := h.service.ListExternalPlugins()
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Failed to list storage plugins: %v", err), http.StatusInternalServerError)
+		return
+	}
+	if plugins == nil {
+		plugins = []*models.ExternalStoragePlugin{}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(plugins)
+}
+
+func (h *StoragePluginHandler) handleInstall(w http.ResponseWriter, r *http.Request) {
+	var req models.ExternalStoragePluginInstallRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, fmt.Sprintf("Invalid request body: %v", err), http.StatusBadRequest)
+		return
+	}
+	if req.RepositoryURL == "" {
+		http.Error(w, "repository_url is required", http.StatusBadRequest)
+		return
+	}
+
+	record, err := h.service.InstallExternalPlugin(&req)
+	if err != nil {
+		// Return 422 so the caller gets the error record (status=error) in the body.
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(record)
+}
+
+func (h *StoragePluginHandler) handleGet(w http.ResponseWriter, r *http.Request, name string) {
+	record, err := h.service.GetExternalPlugin(name)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		http.Error(w, fmt.Sprintf("Failed to get storage plugin: %v", err), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(record)
+}
+
+func (h *StoragePluginHandler) handleUninstall(w http.ResponseWriter, r *http.Request, name string) {
+	if err := h.service.UninstallExternalPlugin(name); err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		http.Error(w, fmt.Sprintf("Failed to uninstall storage plugin: %v", err), http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/pkg/metadatastore/sqlitestore.go
+++ b/pkg/metadatastore/sqlitestore.go
@@ -295,6 +295,19 @@ func (s *SQLiteStore) initSchema() error {
 	CREATE INDEX IF NOT EXISTS idx_dt_predictions_twin_id ON dt_predictions(twin_id);
 	CREATE INDEX IF NOT EXISTS idx_dt_predictions_entity_id ON dt_predictions(entity_id);
 	CREATE INDEX IF NOT EXISTS idx_dt_predictions_cached_until ON dt_predictions(cached_until);
+
+	CREATE TABLE IF NOT EXISTS external_storage_plugins (
+		name TEXT PRIMARY KEY,
+		version TEXT NOT NULL DEFAULT '',
+		description TEXT NOT NULL DEFAULT '',
+		author TEXT NOT NULL DEFAULT '',
+		repository_url TEXT NOT NULL,
+		git_commit_hash TEXT NOT NULL DEFAULT '',
+		status TEXT NOT NULL DEFAULT 'active',
+		error_message TEXT NOT NULL DEFAULT '',
+		installed_at DATETIME NOT NULL,
+		updated_at DATETIME NOT NULL
+	);
 	`
 
 	_, err := s.db.Exec(schema)
@@ -1964,4 +1977,78 @@ func (s *SQLiteStore) DeleteExpiredPredictions(twinID string) error {
 		return fmt.Errorf("failed to delete expired predictions: %w", err)
 	}
 	return nil
+}
+
+// ── External Storage Plugins ─────────────────────────────────────────────────
+
+// SaveExternalStoragePlugin upserts an external storage plugin record.
+func (s *SQLiteStore) SaveExternalStoragePlugin(plugin *models.ExternalStoragePlugin) error {
+	query := `
+		INSERT OR REPLACE INTO external_storage_plugins
+		(name, version, description, author, repository_url, git_commit_hash,
+		 status, error_message, installed_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+	return s.retryOnBusy(func() error {
+		_, err := s.db.Exec(query,
+			plugin.Name, plugin.Version, plugin.Description, plugin.Author,
+			plugin.RepositoryURL, plugin.GitCommitHash,
+			plugin.Status, plugin.ErrorMessage,
+			plugin.InstalledAt.UTC(), plugin.UpdatedAt.UTC(),
+		)
+		return err
+	}, 5)
+}
+
+// GetExternalStoragePlugin retrieves a single external storage plugin by name.
+func (s *SQLiteStore) GetExternalStoragePlugin(name string) (*models.ExternalStoragePlugin, error) {
+	query := `
+		SELECT name, version, description, author, repository_url, git_commit_hash,
+		       status, error_message, installed_at, updated_at
+		FROM external_storage_plugins WHERE name = ?`
+	row := s.db.QueryRow(query, name)
+	p := &models.ExternalStoragePlugin{}
+	if err := row.Scan(
+		&p.Name, &p.Version, &p.Description, &p.Author,
+		&p.RepositoryURL, &p.GitCommitHash,
+		&p.Status, &p.ErrorMessage,
+		&p.InstalledAt, &p.UpdatedAt,
+	); err != nil {
+		return nil, fmt.Errorf("external storage plugin not found: %w", err)
+	}
+	return p, nil
+}
+
+// ListExternalStoragePlugins returns all external storage plugin records.
+func (s *SQLiteStore) ListExternalStoragePlugins() ([]*models.ExternalStoragePlugin, error) {
+	query := `
+		SELECT name, version, description, author, repository_url, git_commit_hash,
+		       status, error_message, installed_at, updated_at
+		FROM external_storage_plugins ORDER BY name`
+	rows, err := s.db.Query(query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list external storage plugins: %w", err)
+	}
+	defer rows.Close()
+	var plugins []*models.ExternalStoragePlugin
+	for rows.Next() {
+		p := &models.ExternalStoragePlugin{}
+		if err := rows.Scan(
+			&p.Name, &p.Version, &p.Description, &p.Author,
+			&p.RepositoryURL, &p.GitCommitHash,
+			&p.Status, &p.ErrorMessage,
+			&p.InstalledAt, &p.UpdatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("failed to scan external storage plugin: %w", err)
+		}
+		plugins = append(plugins, p)
+	}
+	return plugins, nil
+}
+
+// DeleteExternalStoragePlugin removes an external storage plugin record.
+func (s *SQLiteStore) DeleteExternalStoragePlugin(name string) error {
+	return s.retryOnBusy(func() error {
+		_, err := s.db.Exec(`DELETE FROM external_storage_plugins WHERE name = ?`, name)
+		return err
+	}, 5)
 }

--- a/pkg/metadatastore/store.go
+++ b/pkg/metadatastore/store.go
@@ -34,6 +34,12 @@ type MetadataStore interface {
 	DeletePlugin(name string) error
 	UpdatePluginStatus(name string, status models.PluginStatus) error
 
+	// External storage plugin operations
+	SaveExternalStoragePlugin(plugin *models.ExternalStoragePlugin) error
+	GetExternalStoragePlugin(name string) (*models.ExternalStoragePlugin, error)
+	ListExternalStoragePlugins() ([]*models.ExternalStoragePlugin, error)
+	DeleteExternalStoragePlugin(name string) error
+
 	// Storage operations
 	SaveStorageConfig(config *models.StorageConfig) error
 	GetStorageConfig(id string) (*models.StorageConfig, error)

--- a/pkg/models/storage.go
+++ b/pkg/models/storage.go
@@ -1,5 +1,28 @@
 package models
 
+import "time"
+
+// ExternalStoragePlugin records metadata about a dynamically installed storage plugin.
+// The compiled .so is cached on disk; this record tracks its provenance and status.
+type ExternalStoragePlugin struct {
+	Name          string    `json:"name"`
+	Version       string    `json:"version"`
+	Description   string    `json:"description"`
+	Author        string    `json:"author"`
+	RepositoryURL string    `json:"repository_url"`
+	GitCommitHash string    `json:"git_commit_hash"`
+	Status        string    `json:"status"` // "active" | "error"
+	ErrorMessage  string    `json:"error_message,omitempty"`
+	InstalledAt   time.Time `json:"installed_at"`
+	UpdatedAt     time.Time `json:"updated_at"`
+}
+
+// ExternalStoragePluginInstallRequest is the body for POST /api/storage-plugins.
+type ExternalStoragePluginInstallRequest struct {
+	RepositoryURL string `json:"repository_url"`
+	GitRef        string `json:"git_ref,omitempty"` // branch / tag / SHA; defaults to "main"
+}
+
 // StoragePlugin defines the interface that all storage plugins must implement
 // It provides bidirectional translation between CIR format and storage-specific formats
 type StoragePlugin interface {

--- a/pkg/storage/dynamic_loader.go
+++ b/pkg/storage/dynamic_loader.go
@@ -1,0 +1,232 @@
+package storage
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"plugin"
+	"strings"
+
+	"github.com/mimir-aip/mimir-aip-go/pkg/models"
+)
+
+// PluginLoader compiles and loads external storage plugins at runtime.
+// It mirrors the approach used by the worker for pipeline plugins:
+//  1. Clone the Git repository.
+//  2. Flatten the optional actions/ subdirectory to the root.
+//  3. Remove the plugin's go.mod/go.sum (the host module is used instead).
+//  4. Compile with go build -buildmode=plugin using the host module at appDir.
+//  5. Open the resulting .so and resolve the "Plugin" symbol.
+//
+// Compiled .so files are cached at cacheDir so that restarts do not require
+// recompilation (unless the plugin was updated).
+type PluginLoader struct {
+	appDir   string // root of the mimir-aip-go module (e.g. /app)
+	cacheDir string // where .so files are written (e.g. /app/storage-plugins)
+	tempDir  string // scratch space for Git clones
+}
+
+// NewPluginLoader creates a PluginLoader.
+//   - appDir:   the directory that contains the host go.mod (usually /app).
+//   - cacheDir: where compiled .so files are cached between runs.
+//   - tempDir:  temporary directory for git clones (cleaned up after each compile).
+func NewPluginLoader(appDir, cacheDir, tempDir string) (*PluginLoader, error) {
+	for _, d := range []string{cacheDir, tempDir} {
+		if err := os.MkdirAll(d, 0755); err != nil {
+			return nil, fmt.Errorf("storage plugin loader: failed to create directory %s: %w", d, err)
+		}
+	}
+	return &PluginLoader{appDir: appDir, cacheDir: cacheDir, tempDir: tempDir}, nil
+}
+
+// soPath returns the expected .so path for a plugin name.
+func (l *PluginLoader) soPath(name string) string {
+	return filepath.Join(l.cacheDir, name+".so")
+}
+
+// metaPath returns the cache metadata file path for a plugin.
+func (l *PluginLoader) metaPath(name string) string {
+	return l.soPath(name) + ".meta"
+}
+
+// isCached reports whether a compiled .so exists and was built from commitHash.
+func (l *PluginLoader) isCached(name, commitHash string) bool {
+	if _, err := os.Stat(l.soPath(name)); os.IsNotExist(err) {
+		return false
+	}
+	data, err := os.ReadFile(l.metaPath(name))
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(data)) == commitHash
+}
+
+// writeMeta stores the commit hash alongside the .so for cache validation.
+func (l *PluginLoader) writeMeta(name, commitHash string) {
+	if err := os.WriteFile(l.metaPath(name), []byte(commitHash), 0644); err != nil {
+		log.Printf("storage plugin loader: warning — failed to write cache metadata for %s: %v", name, err)
+	}
+}
+
+// CompileAndLoad clones repoURL at commitHash (or gitRef if commitHash is
+// empty), compiles the plugin, and returns a loaded StoragePlugin.
+// If a valid cached .so already exists for commitHash it is used directly.
+func (l *PluginLoader) CompileAndLoad(name, repoURL, gitRef, commitHash string) (models.StoragePlugin, string, error) {
+	if gitRef == "" {
+		gitRef = "main"
+	}
+
+	// Use cached .so if the commit hasn't changed.
+	if commitHash != "" && l.isCached(name, commitHash) {
+		log.Printf("storage plugin loader: using cached .so for %s @ %s", name, commitHash[:8])
+		sp, err := l.openSO(name)
+		return sp, commitHash, err
+	}
+
+	// Clone into a fresh temp directory.
+	cloneDir := filepath.Join(l.tempDir, "sp-"+name+"-clone")
+	_ = os.RemoveAll(cloneDir)
+	if err := l.cloneRepo(repoURL, gitRef, cloneDir); err != nil {
+		return nil, "", err
+	}
+	defer os.RemoveAll(cloneDir)
+
+	// Resolve the actual commit hash so we can cache by it.
+	resolvedHash, err := l.commitHash(cloneDir)
+	if err != nil {
+		log.Printf("storage plugin loader: warning — could not resolve commit hash for %s: %v", name, err)
+		resolvedHash = gitRef
+	}
+
+	// If the resolved hash is already cached we can skip recompilation.
+	if l.isCached(name, resolvedHash) {
+		log.Printf("storage plugin loader: using cached .so for %s @ %s", name, resolvedHash[:min(8, len(resolvedHash))])
+		sp, err := l.openSO(name)
+		return sp, resolvedHash, err
+	}
+
+	// Flatten actions/ subdirectory (same behaviour as the pipeline plugin loader).
+	if err := flattenActions(cloneDir); err != nil {
+		return nil, "", fmt.Errorf("storage plugin loader: flatten actions: %w", err)
+	}
+
+	// Remove the plugin's own go.mod — we compile inside the host module.
+	_ = os.Remove(filepath.Join(cloneDir, "go.mod"))
+	_ = os.Remove(filepath.Join(cloneDir, "go.sum"))
+
+	// Place plugin source inside the host module so it can be built as a
+	// package path relative to appDir.
+	pluginPkg := filepath.Join("storage-plugins", name)
+	pluginSrcDir := filepath.Join(l.appDir, pluginPkg)
+	_ = os.RemoveAll(pluginSrcDir)
+	if err := os.MkdirAll(filepath.Dir(pluginSrcDir), 0755); err != nil {
+		return nil, "", fmt.Errorf("storage plugin loader: mkdir: %w", err)
+	}
+	if err := os.Rename(cloneDir, pluginSrcDir); err != nil {
+		return nil, "", fmt.Errorf("storage plugin loader: move plugin source: %w", err)
+	}
+	defer os.RemoveAll(pluginSrcDir)
+
+	// Compile.
+	soOut := l.soPath(name)
+	buildCmd := exec.Command("go", "build",
+		"-buildmode=plugin",
+		"-trimpath",
+		"-o", soOut,
+		"./"+pluginPkg,
+	)
+	buildCmd.Dir = l.appDir
+	buildCmd.Env = append(os.Environ(), "CGO_ENABLED=1")
+	if out, err := buildCmd.CombinedOutput(); err != nil {
+		return nil, "", fmt.Errorf("storage plugin loader: compilation failed for %s:\n%s\n%w", name, string(out), err)
+	}
+	log.Printf("storage plugin loader: compiled %s successfully", name)
+
+	l.writeMeta(name, resolvedHash)
+
+	sp, err := l.openSO(name)
+	return sp, resolvedHash, err
+}
+
+// LoadCached opens a previously compiled .so without recompiling.
+// Returns an error if the .so does not exist.
+func (l *PluginLoader) LoadCached(name string) (models.StoragePlugin, error) {
+	if _, err := os.Stat(l.soPath(name)); os.IsNotExist(err) {
+		return nil, fmt.Errorf("storage plugin loader: no cached .so for %s — plugin must be reinstalled", name)
+	}
+	return l.openSO(name)
+}
+
+// openSO opens the .so at soPath(name) and resolves the "Plugin" symbol.
+func (l *PluginLoader) openSO(name string) (models.StoragePlugin, error) {
+	p, err := plugin.Open(l.soPath(name))
+	if err != nil {
+		return nil, fmt.Errorf("storage plugin loader: failed to open .so for %s: %w", name, err)
+	}
+	sym, err := p.Lookup("Plugin")
+	if err != nil {
+		return nil, fmt.Errorf("storage plugin loader: %s does not export 'Plugin' symbol: %w", name, err)
+	}
+	// plugin.Lookup returns a pointer to the package-level variable.
+	// If the plugin declares "var Plugin MyPlugin" with pointer-receiver methods,
+	// sym is *MyPlugin which satisfies models.StoragePlugin directly.
+	sp, ok := sym.(models.StoragePlugin)
+	if !ok {
+		return nil, fmt.Errorf("storage plugin loader: Plugin symbol in %s does not implement models.StoragePlugin", name)
+	}
+	return sp, nil
+}
+
+// cloneRepo runs git clone --depth=1 --branch <ref> <url> <dest>.
+func (l *PluginLoader) cloneRepo(repoURL, gitRef, dest string) error {
+	cmd := exec.Command("git", "clone", "--depth=1", "--branch", gitRef, repoURL, dest)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("storage plugin loader: git clone failed: %w\n%s", err, string(out))
+	}
+	return nil
+}
+
+// commitHash returns the HEAD SHA of a local git repository.
+func (l *PluginLoader) commitHash(dir string) (string, error) {
+	cmd := exec.Command("git", "rev-parse", "HEAD")
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// flattenActions moves .go files from actions/ to the plugin root, matching
+// the same behaviour as pkg/plugins/client.go for pipeline plugins.
+func flattenActions(dir string) error {
+	actionsDir := filepath.Join(dir, "actions")
+	if _, err := os.Stat(actionsDir); os.IsNotExist(err) {
+		return nil
+	}
+	entries, err := os.ReadDir(actionsDir)
+	if err != nil {
+		return fmt.Errorf("read actions dir: %w", err)
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".go") {
+			continue
+		}
+		if err := os.Rename(
+			filepath.Join(actionsDir, e.Name()),
+			filepath.Join(dir, e.Name()),
+		); err != nil {
+			return fmt.Errorf("move %s: %w", e.Name(), err)
+		}
+	}
+	return nil
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/pkg/storage/service.go
+++ b/pkg/storage/service.go
@@ -3,6 +3,8 @@ package storage
 import (
 	"fmt"
 	"log"
+	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -13,9 +15,10 @@ import (
 
 // Service provides storage management operations
 type Service struct {
-	store   metadatastore.MetadataStore
-	plugins map[string]models.StoragePlugin
-	mu      sync.RWMutex
+	store        metadatastore.MetadataStore
+	plugins      map[string]models.StoragePlugin
+	mu           sync.RWMutex
+	pluginLoader *PluginLoader // nil when dynamic loading is not configured
 }
 
 // NewService creates a new storage service
@@ -369,6 +372,154 @@ func (s *Service) HealthCheck(storageID string) (bool, error) {
 	}
 
 	return plugin.HealthCheck()
+}
+
+// SetPluginLoader attaches a PluginLoader to the service, enabling dynamic
+// storage plugin installation. Must be called before InstallExternalPlugin.
+func (s *Service) SetPluginLoader(loader *PluginLoader) {
+	s.pluginLoader = loader
+}
+
+// InstallExternalPlugin clones, compiles, and registers a storage plugin from
+// a Git repository. The plugin metadata is persisted so it survives restarts.
+func (s *Service) InstallExternalPlugin(req *models.ExternalStoragePluginInstallRequest) (*models.ExternalStoragePlugin, error) {
+	if s.pluginLoader == nil {
+		return nil, fmt.Errorf("dynamic storage plugin loading is not configured")
+	}
+	if req.RepositoryURL == "" {
+		return nil, fmt.Errorf("repository_url is required")
+	}
+
+	gitRef := req.GitRef
+	if gitRef == "" {
+		gitRef = "main"
+	}
+
+	// Derive a plugin name from the repository URL (last path segment without .git).
+	name := repoName(req.RepositoryURL)
+
+	// Compile (or use cached .so) and load the plugin.
+	sp, commitHash, err := s.pluginLoader.CompileAndLoad(name, req.RepositoryURL, gitRef, "")
+
+	now := time.Now().UTC()
+	record := &models.ExternalStoragePlugin{
+		Name:          name,
+		RepositoryURL: req.RepositoryURL,
+		GitCommitHash: commitHash,
+		Status:        "active",
+		InstalledAt:   now,
+		UpdatedAt:     now,
+	}
+
+	if err != nil {
+		record.Status = "error"
+		record.ErrorMessage = err.Error()
+		// Persist the error record so the user can see what went wrong.
+		_ = s.store.SaveExternalStoragePlugin(record)
+		return record, fmt.Errorf("failed to compile storage plugin %s: %w", name, err)
+	}
+
+	// Register in the live plugin map.
+	s.RegisterPlugin(name, sp)
+
+	if err := s.store.SaveExternalStoragePlugin(record); err != nil {
+		return nil, fmt.Errorf("plugin compiled but failed to persist metadata: %w", err)
+	}
+
+	log.Printf("Installed external storage plugin: %s @ %s", name, commitHash)
+	return record, nil
+}
+
+// ListExternalPlugins returns all persisted external storage plugin records.
+func (s *Service) ListExternalPlugins() ([]*models.ExternalStoragePlugin, error) {
+	return s.store.ListExternalStoragePlugins()
+}
+
+// GetExternalPlugin returns metadata for a single external storage plugin.
+func (s *Service) GetExternalPlugin(name string) (*models.ExternalStoragePlugin, error) {
+	return s.store.GetExternalStoragePlugin(name)
+}
+
+// UninstallExternalPlugin removes the plugin from the live registry and
+// deletes its persisted metadata. The .so file is removed from the cache.
+// Note: Go plugins cannot be unloaded from memory; the process must restart
+// for the removal to take full effect on in-flight storage operations.
+func (s *Service) UninstallExternalPlugin(name string) error {
+	// Remove from live map.
+	s.mu.Lock()
+	delete(s.plugins, name)
+	s.mu.Unlock()
+
+	// Remove .so and meta from cache.
+	if s.pluginLoader != nil {
+		_ = os.Remove(s.pluginLoader.soPath(name))
+		_ = os.Remove(s.pluginLoader.metaPath(name))
+	}
+
+	if err := s.store.DeleteExternalStoragePlugin(name); err != nil {
+		return fmt.Errorf("failed to delete external storage plugin record: %w", err)
+	}
+
+	log.Printf("Uninstalled external storage plugin: %s", name)
+	return nil
+}
+
+// LoadInstalledExternalPlugins re-registers all persisted external storage
+// plugins on startup. If a cached .so exists it is used directly; otherwise
+// the plugin is recompiled from its recorded repository URL and commit hash.
+func (s *Service) LoadInstalledExternalPlugins() error {
+	if s.pluginLoader == nil {
+		return nil
+	}
+
+	records, err := s.store.ListExternalStoragePlugins()
+	if err != nil {
+		return fmt.Errorf("failed to list persisted storage plugins: %w", err)
+	}
+
+	var loadErrs []string
+	for _, rec := range records {
+		if rec.Status == "error" {
+			log.Printf("Skipping external storage plugin %s (status=error)", rec.Name)
+			continue
+		}
+
+		// Try cached .so first.
+		sp, loadErr := s.pluginLoader.LoadCached(rec.Name)
+		if loadErr != nil {
+			// Cache miss — recompile from stored repo+commit.
+			log.Printf("Recompiling external storage plugin %s from %s @ %s", rec.Name, rec.RepositoryURL, rec.GitCommitHash)
+			var compileHash string
+			sp, compileHash, loadErr = s.pluginLoader.CompileAndLoad(
+				rec.Name, rec.RepositoryURL, rec.GitCommitHash, rec.GitCommitHash,
+			)
+			if loadErr != nil {
+				msg := fmt.Sprintf("%s: %v", rec.Name, loadErr)
+				loadErrs = append(loadErrs, msg)
+				rec.Status = "error"
+				rec.ErrorMessage = loadErr.Error()
+				_ = s.store.SaveExternalStoragePlugin(rec)
+				continue
+			}
+			_ = compileHash
+		}
+
+		s.RegisterPlugin(rec.Name, sp)
+		log.Printf("Loaded external storage plugin: %s", rec.Name)
+	}
+
+	if len(loadErrs) > 0 {
+		return fmt.Errorf("failed to load %d external storage plugin(s): %s", len(loadErrs), strings.Join(loadErrs, "; "))
+	}
+	return nil
+}
+
+// repoName derives a plugin name from a Git URL — last path segment without ".git".
+func repoName(repoURL string) string {
+	parts := strings.Split(strings.TrimRight(repoURL, "/"), "/")
+	name := parts[len(parts)-1]
+	name = strings.TrimSuffix(name, ".git")
+	return strings.ToLower(name)
 }
 
 // Helper functions to extract config values


### PR DESCRIPTION
## Summary

- Adds a full Git-clone → compile → load pipeline for custom storage backend plugins, mirroring the existing pipeline step plugin system
- Orchestrator clones the plugin repo, strips its `go.mod`, compiles a `.so` with `go build -buildmode=plugin`, and loads it via `plugin.Open` + `plugin.Lookup("Plugin")`
- Plugins persist across restarts — installed plugins are stored in SQLite and reloaded on startup
- REST API for install, list, get, and uninstall (`/api/storage-plugins`)

## Changes

| Area | What changed |
|------|-------------|
| `pkg/models/storage.go` | Added `ExternalStoragePlugin` and `ExternalStoragePluginInstallRequest` types |
| `pkg/metadatastore/` | `external_storage_plugins` table + 4 CRUD implementations |
| `pkg/storage/dynamic_loader.go` | New `PluginLoader` — clone, flatten `actions/`, compile, cache, open `.so` |
| `pkg/storage/service.go` | `InstallExternalPlugin`, `ListExternalPlugins`, `GetExternalPlugin`, `UninstallExternalPlugin`, `LoadInstalledExternalPlugins` |
| `pkg/api/storage_plugin_handler.go` | REST handler for `/api/storage-plugins` |
| `cmd/orchestrator/main.go` | Plugin loader init + route registration |
| `cmd/orchestrator/Dockerfile` | Runtime base changed from `debian:bookworm-slim` → `golang:1.25` (needed for `go build -buildmode=plugin` at runtime) |

## Test plan

- [ ] `go test ./pkg/...` passes
- [ ] `go vet ./...` clean
- [ ] `POST /api/storage-plugins` with a valid repo URL installs and loads the plugin
- [ ] `GET /api/storage-plugins` lists installed plugins
- [ ] `DELETE /api/storage-plugins/{name}` removes from registry
- [ ] Orchestrator restart reloads previously installed plugins from SQLite

🤖 Generated with [Claude Code](https://claude.com/claude-code)