### PR TITLE
feat: OpenAPI auto-discovery via route registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,63 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  test:
+    name: Test & Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Verify dependencies
+        run: go mod verify
+
+      - name: Build orchestrator
+        run: go build ./cmd/orchestrator/...
+
+      - name: Build worker
+        run: go build ./cmd/worker/...
+
+      - name: Run go vet
+        run: go vet ./...
+
+      - name: Run unit tests
+        run: go test -race -timeout 120s ./pkg/...
+
+  openapi-check:
+    name: OpenAPI spec up to date
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Regenerate OpenAPI spec
+        run: go run ./cmd/openapi-gen > docs/openapi.yaml
+
+      - name: Check for diff
+        run: |
+          if ! git diff --exit-code docs/openapi.yaml; then
+            echo ""
+            echo "ERROR: docs/openapi.yaml is out of date."
+            echo "Run 'go run ./cmd/openapi-gen > docs/openapi.yaml' and commit the result."
+            exit 1
+          fi

--- a/cmd/openapi-gen/main.go
+++ b/cmd/openapi-gen/main.go
@@ -1,0 +1,29 @@
+// cmd/openapi-gen generates the OpenAPI 3.0 specification for the Mimir AIP
+// orchestrator by importing the api package (which triggers every handler's
+// init() route-registration) and then calling doc.GenerateSpec().
+//
+// Usage:
+//
+//	go run ./cmd/openapi-gen > docs/openapi.yaml
+//
+// The generated file is committed to the repository. CI enforces that it
+// stays in sync: if a developer adds an endpoint without regenerating the
+// spec the openapi-check job will fail.
+package main
+
+import (
+	"fmt"
+	"os"
+
+	_ "github.com/mimir-aip/mimir-aip-go/pkg/api" // triggers all init() route registrations
+	"github.com/mimir-aip/mimir-aip-go/pkg/api/doc"
+)
+
+func main() {
+	spec, err := doc.GenerateSpec()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "openapi-gen: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Print(spec)
+}

--- a/docs/custom-plugins.md
+++ b/docs/custom-plugins.md
@@ -1,0 +1,198 @@
+# Custom Plugins for Mimir AIP
+
+Mimir supports two kinds of runtime-extensible plugins:
+
+1. **Pipeline Step Plugins** — custom processing steps that workers execute inside pipelines
+2. **Storage Plugins** — custom storage backends that the orchestrator loads at runtime
+
+---
+
+## Part 1 — Pipeline Step Plugins
+
+Pipeline step plugins let you add new processing steps without modifying the core Mimir codebase. Workers clone, compile, and execute your plugin as a Go plugin (`.so`) at runtime.
+
+### Plugin Interface
+
+Your plugin must implement the `Plugin` interface from the Mimir worker:
+
+```go
+type Plugin interface {
+    Execute(ctx context.Context, input map[string]interface{}) (map[string]interface{}, error)
+}
+```
+
+The optional `GetActions() []string` method is supported but not required.
+
+### Repository Structure
+
+```
+my-plugin/
+├── plugin.go          # Required: exports var Plugin
+├── plugin.yaml        # Required: plugin manifest
+├── go.mod             # Present in your repo but DELETED by the worker before compilation
+└── actions/           # Optional: action handlers (files are flattened to root at compile time)
+    ├── ingest.go
+    └── transform.go
+```
+
+> **Important:** The worker deletes your plugin's `go.mod` and `go.sum` before compilation. Your plugin is compiled as part of the host module using the same dependency versions as the orchestrator. You do not need to pin any Mimir dependencies in your `go.mod` — it exists only for local development / IDE support.
+
+### plugin.yaml
+
+```yaml
+name: my-plugin
+version: "1.0.0"
+description: "Does something useful"
+author: "Your Name"
+actions:
+  - ingest
+  - transform
+```
+
+### Required Export
+
+Your plugin must export a package-level variable named `Plugin`:
+
+```go
+package main
+
+import "context"
+
+type MyPlugin struct{}
+
+func (p *MyPlugin) Execute(ctx context.Context, input map[string]interface{}) (map[string]interface{}, error) {
+    // process input...
+    return map[string]interface{}{"result": "ok"}, nil
+}
+
+func (p *MyPlugin) GetActions() []string {
+    return []string{"ingest", "transform"}
+}
+
+var Plugin MyPlugin
+```
+
+The worker uses `plugin.Lookup("Plugin")` which returns a `*MyPlugin`. Since the interface methods use pointer receivers, `*MyPlugin` satisfies the interface — this is why the export is a value type, not a pointer.
+
+### actions/ Directory
+
+If your plugin has multiple action handlers, place them in an `actions/` subdirectory. The worker's `flattenActionFiles()` moves all `.go` files from `actions/` into the root before compilation:
+
+```
+actions/
+├── ingest.go    # func init() { register("ingest", handleIngest) }
+└── transform.go # func init() { register("transform", handleTransform) }
+```
+
+### Installing a Plugin
+
+```bash
+curl -X POST http://localhost:8080/api/plugins \
+  -H "Content-Type: application/json" \
+  -d '{"repository_url": "https://github.com/your-org/my-plugin", "git_ref": "main"}'
+```
+
+The worker clones, compiles, and caches the `.so` automatically on next use.
+
+---
+
+## Part 2 — Storage Plugins
+
+Storage plugins let you connect Mimir to any data backend by implementing a Go interface and hosting the plugin in a Git repository. The orchestrator clones, compiles (using `go build -buildmode=plugin`), and loads the `.so` at runtime — no restart required.
+
+### StoragePlugin Interface
+
+```go
+// From pkg/models/storage.go
+type StoragePlugin interface {
+    Initialize(config map[string]interface{}) error
+    Store(data []CIR) (*StorageResult, error)
+    Retrieve(query CIRQuery) ([]CIR, error)
+    Update(query CIRQuery, updates map[string]interface{}) (*StorageResult, error)
+    Delete(query CIRQuery) (*StorageResult, error)
+    HealthCheck() (bool, error)
+    GetCapabilities() StorageCapabilities
+    Close() error
+}
+```
+
+### Repository Structure
+
+```
+my-storage-plugin/
+├── plugin.go          # Required: exports var Plugin
+├── go.mod             # For local development; DELETED by the loader before compilation
+└── actions/           # Optional action files (flattened at compile time)
+```
+
+### Implementation Skeleton
+
+```go
+package main
+
+import (
+    "github.com/mimir-aip/mimir-aip-go/pkg/models"
+)
+
+type MyStoragePlugin struct {
+    cfg map[string]interface{}
+}
+
+func (p *MyStoragePlugin) Initialize(config map[string]interface{}) error {
+    p.cfg = config
+    // open connection...
+    return nil
+}
+
+func (p *MyStoragePlugin) Store(data []models.CIR) (*models.StorageResult, error) {
+    // write records...
+    return &models.StorageResult{RecordsAffected: int64(len(data))}, nil
+}
+
+func (p *MyStoragePlugin) Retrieve(query models.CIRQuery) ([]models.CIR, error) {
+    // query records...
+    return nil, nil
+}
+
+func (p *MyStoragePlugin) Update(query models.CIRQuery, updates map[string]interface{}) (*models.StorageResult, error) {
+    return &models.StorageResult{}, nil
+}
+
+func (p *MyStoragePlugin) Delete(query models.CIRQuery) (*models.StorageResult, error) {
+    return &models.StorageResult{}, nil
+}
+
+func (p *MyStoragePlugin) HealthCheck() (bool, error) { return true, nil }
+
+func (p *MyStoragePlugin) GetCapabilities() models.StorageCapabilities {
+    return models.StorageCapabilities{SupportsQuery: true}
+}
+
+func (p *MyStoragePlugin) Close() error { return nil }
+
+// Plugin is the exported symbol the loader looks up via plugin.Lookup("Plugin").
+var Plugin MyStoragePlugin
+```
+
+> **Note:** Go plugins cannot be unloaded from memory once opened. Uninstalling a storage plugin removes it from the registry and deletes the cached `.so`, but a full orchestrator restart is needed for complete removal.
+
+### Installing a Storage Plugin
+
+```bash
+curl -X POST http://localhost:8080/api/storage-plugins \
+  -H "Content-Type: application/json" \
+  -d '{"repository_url": "https://github.com/your-org/my-storage-plugin", "git_ref": "v1.0.0"}'
+```
+
+The orchestrator clones the repository, compiles the `.so`, loads it, and registers it as a new storage backend type. The plugin name is derived from the repository name (last path segment, `.git` stripped, lowercased).
+
+### Runtime Requirements
+
+The orchestrator container must have the Go toolchain available at runtime (for `go build -buildmode=plugin`). The official Mimir orchestrator Docker image is based on `golang:1.25` for this reason.
+
+---
+
+## Further Reading
+
+- [OpenAPI specification](./openapi.yaml) — all REST endpoints, including the plugin management APIs
+- [Reference pipeline plugin](https://github.com/Mimir-AIP/OpenLibraryMimirPlugin) — a complete, production example

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,2888 @@
+components:
+    schemas:
+        ActionRequest:
+            properties:
+                action_type:
+                    description: Type of action to apply
+                    type: string
+                parameters:
+                    additionalProperties: true
+                    type: object
+            required:
+                - action_type
+            type: object
+        ActionResult:
+            properties:
+                action_id:
+                    description: Action ID
+                    type: string
+                applied_at:
+                    description: ISO-8601 timestamp
+                    type: string
+                result:
+                    additionalProperties: true
+                    type: object
+                status:
+                    description: Action status
+                    type: string
+            type: object
+        CIR:
+            description: Common Internal Representation — the normalised record format used across all storage backends.
+            properties:
+                data:
+                    additionalProperties: true
+                    description: Record payload
+                    type: object
+                id:
+                    description: CIR record ID
+                    type: string
+                metadata:
+                    additionalProperties: true
+                    description: Record metadata
+                    type: object
+                source:
+                    additionalProperties: true
+                    description: Provenance information
+                    type: object
+            type: object
+        CIRCondition:
+            properties:
+                attribute:
+                    description: Attribute name
+                    type: string
+                operator:
+                    description: eq | neq | gt | gte | lt | lte | in | like
+                    type: string
+                value:
+                    description: Filter value
+            required:
+                - attribute
+                - operator
+                - value
+            type: object
+        CIRQuery:
+            properties:
+                entity_type:
+                    description: Filter by entity type
+                    type: string
+                filters:
+                    items:
+                        $ref: '#/components/schemas/CIRCondition'
+                    type: array
+                limit:
+                    description: Maximum results
+                    type: integer
+                offset:
+                    description: Pagination offset
+                    type: integer
+                order_by:
+                    items:
+                        $ref: '#/components/schemas/OrderByClause'
+                    type: array
+            type: object
+        DigitalTwin:
+            properties:
+                created_at:
+                    description: ISO-8601 creation timestamp
+                    type: string
+                description:
+                    description: Description
+                    type: string
+                entity_count:
+                    description: Number of entities in the graph
+                    type: integer
+                id:
+                    description: Digital twin ID (UUID)
+                    type: string
+                metadata:
+                    additionalProperties: true
+                    type: object
+                name:
+                    description: Digital twin name
+                    type: string
+                ontology_id:
+                    description: Linked ontology ID
+                    type: string
+                project_id:
+                    description: Owning project ID
+                    type: string
+                status:
+                    description: initialising | active | syncing | error
+                    type: string
+                updated_at:
+                    description: ISO-8601 last-updated timestamp
+                    type: string
+            type: object
+        DigitalTwinCreateRequest:
+            properties:
+                description:
+                    description: Description
+                    type: string
+                name:
+                    description: Digital twin name
+                    type: string
+                ontology_id:
+                    description: Linked ontology ID
+                    type: string
+                project_id:
+                    description: Owning project ID
+                    type: string
+            required:
+                - project_id
+                - name
+            type: object
+        DigitalTwinUpdateRequest:
+            properties:
+                description:
+                    description: New description
+                    type: string
+                name:
+                    description: New name
+                    type: string
+                ontology_id:
+                    description: New linked ontology ID
+                    type: string
+            type: object
+        Entity:
+            properties:
+                attributes:
+                    additionalProperties: true
+                    type: object
+                computed_values:
+                    additionalProperties: true
+                    type: object
+                id:
+                    description: Entity ID (UUID)
+                    type: string
+                last_updated:
+                    description: ISO-8601 last-updated timestamp
+                    type: string
+                relationships:
+                    items:
+                        description: Relationship to another entity
+                        type: object
+                    type: array
+                type:
+                    description: Entity type (from ontology)
+                    type: string
+            type: object
+        ExternalStoragePlugin:
+            properties:
+                author:
+                    description: Author from plugin.yaml
+                    type: string
+                description:
+                    description: Description from plugin.yaml
+                    type: string
+                error_message:
+                    description: Compilation or load error, if status=error
+                    type: string
+                git_commit_hash:
+                    description: Commit SHA the current .so was compiled from
+                    type: string
+                installed_at:
+                    description: ISO-8601 installation timestamp
+                    type: string
+                name:
+                    description: Plugin name (derived from repository URL)
+                    type: string
+                repository_url:
+                    description: Git repository URL
+                    type: string
+                status:
+                    description: active | error
+                    type: string
+                updated_at:
+                    description: ISO-8601 last-updated timestamp
+                    type: string
+                version:
+                    description: Version from plugin.yaml
+                    type: string
+            type: object
+        ExternalStoragePluginInstallRequest:
+            properties:
+                git_ref:
+                    description: 'Branch, tag, or commit SHA (default: main)'
+                    type: string
+                repository_url:
+                    description: HTTPS Git URL of the storage plugin repository
+                    type: string
+            required:
+                - repository_url
+            type: object
+        ExtractionRequest:
+            properties:
+                ontology_id:
+                    description: Existing ontology to diff against (optional)
+                    type: string
+                project_id:
+                    description: Project ID
+                    type: string
+                storage_id:
+                    description: Storage config ID to extract from
+                    type: string
+            required:
+                - project_id
+                - storage_id
+            type: object
+        ExtractionResult:
+            properties:
+                diff:
+                    description: OntologyDiff — added/removed/modified classes and properties
+                    type: object
+                needs_review:
+                    description: True if the diff is significant enough to flag for human review
+                    type: boolean
+                ontology:
+                    $ref: '#/components/schemas/Ontology'
+            type: object
+        MLModel:
+            properties:
+                created_at:
+                    description: ISO-8601 creation timestamp
+                    type: string
+                description:
+                    description: Model description
+                    type: string
+                id:
+                    description: ML model ID (UUID)
+                    type: string
+                is_recommended:
+                    description: True if recommended by the recommendation engine
+                    type: boolean
+                metadata:
+                    additionalProperties: true
+                    type: object
+                model_artifact_path:
+                    description: Path to the serialised model artifact
+                    type: string
+                name:
+                    description: Model name
+                    type: string
+                ontology_id:
+                    description: Linked ontology ID
+                    type: string
+                performance_metrics:
+                    description: Latest performance metrics
+                    type: object
+                project_id:
+                    description: Owning project ID
+                    type: string
+                recommendation_score:
+                    description: Recommendation engine score
+                    type: integer
+                status:
+                    description: draft | training | trained | failed | degraded | deprecated | archived
+                    type: string
+                training_config:
+                    description: Training configuration
+                    type: object
+                training_metrics:
+                    description: Metrics recorded during training
+                    type: object
+                type:
+                    description: decision_tree | random_forest | regression | neural_network
+                    type: string
+                updated_at:
+                    description: ISO-8601 last-updated timestamp
+                    type: string
+                version:
+                    description: Model version string
+                    type: string
+            type: object
+        MLModelCreateRequest:
+            properties:
+                description:
+                    description: Description
+                    type: string
+                name:
+                    description: Model name
+                    type: string
+                ontology_id:
+                    description: Linked ontology ID
+                    type: string
+                project_id:
+                    description: Owning project ID
+                    type: string
+                training_config:
+                    description: Training configuration
+                    type: object
+                type:
+                    description: Model type
+                    type: string
+            required:
+                - project_id
+                - name
+                - type
+            type: object
+        MLModelRecommendRequest:
+            properties:
+                ontology_id:
+                    description: Ontology to base recommendation on
+                    type: string
+                project_id:
+                    description: Project ID
+                    type: string
+                storage_id:
+                    description: Storage config to sample data from
+                    type: string
+            required:
+                - project_id
+            type: object
+        MLModelRecommendation:
+            properties:
+                alternatives:
+                    items:
+                        description: Alternative model type with score and reason
+                        type: object
+                    type: array
+                reason:
+                    description: Explanation
+                    type: string
+                recommended_type:
+                    description: Recommended model type
+                    type: string
+                score:
+                    description: Confidence score (0-100)
+                    type: integer
+            type: object
+        MLModelUpdateRequest:
+            properties:
+                description:
+                    description: New description
+                    type: string
+                name:
+                    description: New name
+                    type: string
+                status:
+                    description: New status
+                    type: string
+                training_config:
+                    description: Updated training configuration
+                    type: object
+            type: object
+        MLTrainingRequest:
+            properties:
+                model_id:
+                    description: ID of the model to train
+                    type: string
+                storage_id:
+                    description: Storage config to load training data from
+                    type: string
+            required:
+                - model_id
+            type: object
+        MetricsResponse:
+            properties:
+                queue:
+                    properties:
+                        length:
+                            description: Current queue depth
+                            type: integer
+                    type: object
+                tasks_by_status:
+                    additionalProperties:
+                        type: integer
+                    type: object
+                tasks_by_type:
+                    additionalProperties:
+                        type: integer
+                    type: object
+                timestamp:
+                    description: ISO-8601 UTC snapshot timestamp
+                    type: string
+            type: object
+        Ontology:
+            properties:
+                content:
+                    description: OWL/Turtle ontology content
+                    type: string
+                created_at:
+                    description: ISO-8601 creation timestamp
+                    type: string
+                description:
+                    description: Ontology description
+                    type: string
+                id:
+                    description: Ontology ID (UUID)
+                    type: string
+                name:
+                    description: Ontology name
+                    type: string
+                project_id:
+                    description: Owning project ID
+                    type: string
+                status:
+                    description: draft | active | needs_review | deprecated
+                    type: string
+                updated_at:
+                    description: ISO-8601 last-updated timestamp
+                    type: string
+            type: object
+        OntologyCreateRequest:
+            properties:
+                content:
+                    description: Initial OWL/Turtle content
+                    type: string
+                description:
+                    description: Description
+                    type: string
+                name:
+                    description: Ontology name
+                    type: string
+                project_id:
+                    description: Owning project ID
+                    type: string
+            required:
+                - project_id
+                - name
+            type: object
+        OntologyUpdateRequest:
+            properties:
+                content:
+                    description: Updated OWL/Turtle content
+                    type: string
+                description:
+                    description: New description
+                    type: string
+                name:
+                    description: New name
+                    type: string
+                status:
+                    description: New status
+                    type: string
+            type: object
+        OrderByClause:
+            properties:
+                attribute:
+                    description: Attribute to sort by
+                    type: string
+                direction:
+                    description: asc | desc (default asc)
+                    type: string
+            required:
+                - attribute
+            type: object
+        Pipeline:
+            properties:
+                created_at:
+                    description: ISO-8601 creation timestamp
+                    type: string
+                description:
+                    description: Pipeline description
+                    type: string
+                id:
+                    description: Pipeline ID (UUID)
+                    type: string
+                name:
+                    description: Pipeline name
+                    type: string
+                project_id:
+                    description: Owning project ID
+                    type: string
+                status:
+                    description: Pipeline status
+                    type: string
+                steps:
+                    items:
+                        $ref: '#/components/schemas/PipelineStep'
+                    type: array
+                type:
+                    description: ingestion | processing | output
+                    type: string
+                updated_at:
+                    description: ISO-8601 last-updated timestamp
+                    type: string
+            type: object
+        PipelineCreateRequest:
+            properties:
+                description:
+                    description: Pipeline description
+                    type: string
+                name:
+                    description: Pipeline name
+                    type: string
+                project_id:
+                    description: Owning project ID
+                    type: string
+                steps:
+                    items:
+                        $ref: '#/components/schemas/PipelineStep'
+                    type: array
+                type:
+                    description: Pipeline type
+                    type: string
+            required:
+                - project_id
+                - name
+                - type
+                - steps
+            type: object
+        PipelineExecutionRequest:
+            properties:
+                parameters:
+                    additionalProperties: true
+                    type: object
+                pipeline_id:
+                    description: Pipeline ID to execute
+                    type: string
+                trigger_type:
+                    description: manual | scheduled | automatic
+                    type: string
+                triggered_by:
+                    description: Trigger source identifier
+                    type: string
+            required:
+                - pipeline_id
+            type: object
+        PipelineStep:
+            properties:
+                action:
+                    description: Action name within the plugin
+                    type: string
+                name:
+                    description: Step name (unique within pipeline)
+                    type: string
+                output:
+                    additionalProperties:
+                        type: string
+                    type: object
+                parameters:
+                    additionalProperties: true
+                    type: object
+                plugin:
+                    description: Plugin name or 'default' for built-in actions
+                    type: string
+            required:
+                - name
+                - plugin
+                - action
+            type: object
+        PipelineUpdateRequest:
+            properties:
+                description:
+                    description: New description
+                    type: string
+                status:
+                    description: New status
+                    type: string
+                steps:
+                    items:
+                        $ref: '#/components/schemas/PipelineStep'
+                    type: array
+            type: object
+        Plugin:
+            properties:
+                actions:
+                    items:
+                        type: string
+                    type: array
+                author:
+                    description: Plugin author
+                    type: string
+                description:
+                    description: Plugin description
+                    type: string
+                installed_at:
+                    description: ISO-8601 installation timestamp
+                    type: string
+                name:
+                    description: Plugin name
+                    type: string
+                repository_url:
+                    description: Git repository URL
+                    type: string
+                version:
+                    description: Plugin version
+                    type: string
+            type: object
+        PluginInstallRequest:
+            properties:
+                git_ref:
+                    description: 'Branch, tag, or commit SHA (default: main)'
+                    type: string
+                repository_url:
+                    description: HTTPS Git URL of the plugin repository
+                    type: string
+            required:
+                - repository_url
+            type: object
+        PluginUpdateRequest:
+            properties:
+                git_ref:
+                    description: Branch, tag, or commit SHA to update to
+                    type: string
+            type: object
+        Project:
+            properties:
+                components:
+                    properties:
+                        digital_twins:
+                            items:
+                                type: string
+                            type: array
+                        ml_models:
+                            items:
+                                type: string
+                            type: array
+                        ontologies:
+                            items:
+                                type: string
+                            type: array
+                        pipelines:
+                            items:
+                                type: string
+                            type: array
+                        storage:
+                            items:
+                                type: string
+                            type: array
+                    type: object
+                created_at:
+                    description: ISO-8601 creation timestamp
+                    type: string
+                description:
+                    description: Project description
+                    type: string
+                id:
+                    description: Project ID (UUID)
+                    type: string
+                name:
+                    description: Project name
+                    type: string
+                status:
+                    description: active | archived
+                    type: string
+                updated_at:
+                    description: ISO-8601 last-updated timestamp
+                    type: string
+            type: object
+        ProjectCloneRequest:
+            properties:
+                name:
+                    description: Name for the cloned project
+                    type: string
+                project_id:
+                    description: ID of the project to clone
+                    type: string
+            required:
+                - project_id
+                - name
+            type: object
+        ProjectCreateRequest:
+            properties:
+                description:
+                    description: Project description
+                    type: string
+                name:
+                    description: Project name
+                    type: string
+            required:
+                - name
+            type: object
+        ProjectUpdateRequest:
+            properties:
+                description:
+                    description: New description
+                    type: string
+                name:
+                    description: New name
+                    type: string
+                status:
+                    description: New status
+                    type: string
+            type: object
+        ScenarioRequest:
+            properties:
+                modifications:
+                    items:
+                        description: Entity attribute modification
+                        type: object
+                    type: array
+                scenario_id:
+                    description: Optional scenario ID (generated if omitted)
+                    type: string
+            required:
+                - modifications
+            type: object
+        ScenarioResult:
+            properties:
+                created_at:
+                    description: ISO-8601 timestamp
+                    type: string
+                entities:
+                    items:
+                        $ref: '#/components/schemas/Entity'
+                    type: array
+                predictions:
+                    additionalProperties: true
+                    type: object
+                scenario_id:
+                    description: Scenario ID
+                    type: string
+            type: object
+        Schedule:
+            properties:
+                created_at:
+                    description: ISO-8601 creation timestamp
+                    type: string
+                cron:
+                    description: Cron expression (e.g. '0 * * * *')
+                    type: string
+                enabled:
+                    description: Whether the schedule is active
+                    type: boolean
+                id:
+                    description: Schedule ID (UUID)
+                    type: string
+                name:
+                    description: Schedule name
+                    type: string
+                pipeline_ids:
+                    items:
+                        type: string
+                    type: array
+                updated_at:
+                    description: ISO-8601 last-updated timestamp
+                    type: string
+            type: object
+        ScheduleCreateRequest:
+            properties:
+                cron:
+                    description: Cron expression
+                    type: string
+                enabled:
+                    description: Start enabled (default true)
+                    type: boolean
+                name:
+                    description: Schedule name
+                    type: string
+                pipeline_ids:
+                    items:
+                        type: string
+                    type: array
+            required:
+                - name
+                - cron
+                - pipeline_ids
+            type: object
+        ScheduleUpdateRequest:
+            properties:
+                cron:
+                    description: New cron expression
+                    type: string
+                enabled:
+                    description: Enable or disable
+                    type: boolean
+                name:
+                    description: New name
+                    type: string
+                pipeline_ids:
+                    items:
+                        type: string
+                    type: array
+            type: object
+        StorageConfig:
+            properties:
+                active:
+                    description: Whether this config is active
+                    type: boolean
+                config:
+                    additionalProperties: true
+                    type: object
+                created_at:
+                    description: ISO-8601 creation timestamp
+                    type: string
+                id:
+                    description: Storage config ID (UUID)
+                    type: string
+                ontology_id:
+                    description: Optional linked ontology ID
+                    type: string
+                plugin_type:
+                    description: filesystem | postgresql | mysql | mongodb | s3 | redis | elasticsearch | neo4j | <custom>
+                    type: string
+                project_id:
+                    description: Owning project ID
+                    type: string
+                updated_at:
+                    description: ISO-8601 last-updated timestamp
+                    type: string
+            type: object
+        StorageConfigCreateRequest:
+            properties:
+                config:
+                    additionalProperties: true
+                    type: object
+                ontology_id:
+                    description: Optional linked ontology ID
+                    type: string
+                plugin_type:
+                    description: Backend type
+                    type: string
+                project_id:
+                    description: Owning project ID
+                    type: string
+            required:
+                - project_id
+                - plugin_type
+                - config
+            type: object
+        StorageConfigUpdateRequest:
+            properties:
+                active:
+                    description: Active flag
+                    type: boolean
+                config:
+                    additionalProperties: true
+                    type: object
+                ontology_id:
+                    description: Linked ontology ID
+                    type: string
+            type: object
+        StorageDeleteRequest:
+            properties:
+                project_id:
+                    description: Project ID
+                    type: string
+                query:
+                    $ref: '#/components/schemas/CIRQuery'
+                storage_id:
+                    description: Storage config ID
+                    type: string
+            required:
+                - project_id
+                - storage_id
+                - query
+            type: object
+        StorageQueryRequest:
+            properties:
+                project_id:
+                    description: Project ID
+                    type: string
+                query:
+                    $ref: '#/components/schemas/CIRQuery'
+                storage_id:
+                    description: Storage config ID
+                    type: string
+            required:
+                - project_id
+                - storage_id
+            type: object
+        StorageResult:
+            properties:
+                affected_items:
+                    description: Number of records affected
+                    type: integer
+                error:
+                    description: Error message if unsuccessful
+                    type: string
+                success:
+                    description: Whether the operation succeeded
+                    type: boolean
+            type: object
+        StorageStoreRequest:
+            properties:
+                cir_data:
+                    $ref: '#/components/schemas/CIR'
+                project_id:
+                    description: Project ID
+                    type: string
+                storage_id:
+                    description: Storage config ID
+                    type: string
+            required:
+                - project_id
+                - storage_id
+                - cir_data
+            type: object
+        StorageUpdateRequest:
+            properties:
+                project_id:
+                    description: Project ID
+                    type: string
+                query:
+                    $ref: '#/components/schemas/CIRQuery'
+                storage_id:
+                    description: Storage config ID
+                    type: string
+                updates:
+                    properties:
+                        filters:
+                            items:
+                                $ref: '#/components/schemas/CIRCondition'
+                            type: array
+                        updates:
+                            additionalProperties: true
+                            type: object
+                    type: object
+            required:
+                - project_id
+                - storage_id
+                - query
+                - updates
+            type: object
+        WorkTask:
+            properties:
+                completed_at:
+                    description: ISO-8601 completion timestamp
+                    type: string
+                error_message:
+                    description: Error message if task failed
+                    type: string
+                id:
+                    description: Work task ID (UUID)
+                    type: string
+                max_retries:
+                    description: Maximum retry attempts
+                    type: integer
+                priority:
+                    description: Task priority (higher = processed first)
+                    type: integer
+                project_id:
+                    description: Owning project ID
+                    type: string
+                resource_requirements:
+                    additionalProperties: true
+                    type: object
+                retry_count:
+                    description: Number of retries so far
+                    type: integer
+                started_at:
+                    description: ISO-8601 start timestamp
+                    type: string
+                status:
+                    description: queued | running | completed | failed
+                    type: string
+                submitted_at:
+                    description: ISO-8601 submission timestamp
+                    type: string
+                task_spec:
+                    additionalProperties: true
+                    type: object
+                type:
+                    description: pipeline_execution | ml_training | ml_inference | digital_twin_update
+                    type: string
+            type: object
+        WorkTaskResult:
+            properties:
+                error_message:
+                    description: Error message if failed
+                    type: string
+                result:
+                    additionalProperties: true
+                    type: object
+                status:
+                    description: completed | failed
+                    type: string
+            required:
+                - status
+            type: object
+        WorkTaskSubmissionRequest:
+            properties:
+                data_access:
+                    additionalProperties: true
+                    type: object
+                priority:
+                    description: Task priority
+                    type: integer
+                project_id:
+                    description: Owning project ID
+                    type: string
+                resource_requirements:
+                    additionalProperties: true
+                    type: object
+                task_spec:
+                    additionalProperties: true
+                    type: object
+                type:
+                    description: Task type
+                    type: string
+            required:
+                - type
+                - project_id
+            type: object
+info:
+    contact:
+        name: Mimir AIP
+        url: https://github.com/Mimir-AIP/Mimir-AIP-Go
+    description: REST API for the Mimir AIP orchestrator. This specification is generated automatically from inline route registrations — it stays in sync with the codebase by construction.
+    license:
+        name: See repository
+        url: https://github.com/Mimir-AIP/Mimir-AIP-Go/blob/main/LICENSE
+    title: Mimir AIP REST API
+    version: 0.1.0
+openapi: 3.0.3
+paths:
+    /api/digital-twins:
+        get:
+            description: Returns all digital twins for a project.
+            parameters:
+                - description: Filter by project ID
+                  in: query
+                  name: project_id
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                items:
+                                    $ref: '#/components/schemas/DigitalTwin'
+                                type: array
+                    description: 200 OK
+            summary: List digital twins
+            tags:
+                - Digital Twins
+        post:
+            description: Creates a new digital twin and initialises its entity graph from the associated ontology.
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/DigitalTwinCreateRequest'
+                required: true
+            responses:
+                "201":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/DigitalTwin'
+                    description: Created
+                "400":
+                    description: Bad request — invalid input
+            summary: Create digital twin
+            tags:
+                - Digital Twins
+    /api/digital-twins/{id}:
+        delete:
+            description: ""
+            parameters:
+                - description: Digital twin ID
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "204":
+                    description: No content
+                "404":
+                    description: Resource not found
+            summary: Delete digital twin
+            tags:
+                - Digital Twins
+        get:
+            description: ""
+            parameters:
+                - description: Digital twin ID
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/DigitalTwin'
+                    description: 200 OK
+                "404":
+                    description: Resource not found
+            summary: Get digital twin
+            tags:
+                - Digital Twins
+        put:
+            description: ""
+            parameters:
+                - description: Digital twin ID
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/DigitalTwinUpdateRequest'
+                required: true
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/DigitalTwin'
+                    description: 200 OK
+                "400":
+                    description: Bad request — invalid input
+                "404":
+                    description: Resource not found
+            summary: Update digital twin
+            tags:
+                - Digital Twins
+    /api/digital-twins/{id}/actions:
+        get:
+            description: ""
+            parameters:
+                - description: Digital twin ID
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                items:
+                                    $ref: '#/components/schemas/Action'
+                                type: array
+                    description: 200 OK
+            summary: List actions
+            tags:
+                - Digital Twins
+        post:
+            description: Registers an action that can be applied to entities within the digital twin.
+            parameters:
+                - description: Digital twin ID
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/ActionCreateRequest'
+                required: true
+            responses:
+                "201":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Action'
+                    description: Created
+                "400":
+                    description: Bad request — invalid input
+            summary: Create action
+            tags:
+                - Digital Twins
+    /api/digital-twins/{id}/actions/{actionId}:
+        delete:
+            description: ""
+            parameters:
+                - description: Digital twin ID
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+                - description: Action ID
+                  in: path
+                  name: actionId
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "204":
+                    description: No content
+                "404":
+                    description: Resource not found
+            summary: Delete action
+            tags:
+                - Digital Twins
+        get:
+            description: ""
+            parameters:
+                - description: Digital twin ID
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+                - description: Action ID
+                  in: path
+                  name: actionId
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Action'
+                    description: 200 OK
+                "404":
+                    description: Resource not found
+            summary: Get action
+            tags:
+                - Digital Twins
+    /api/digital-twins/{id}/entities:
+        get:
+            description: ""
+            parameters:
+                - description: Digital twin ID
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                items:
+                                    $ref: '#/components/schemas/Entity'
+                                type: array
+                    description: 200 OK
+            summary: List entities
+            tags:
+                - Digital Twins
+    /api/digital-twins/{id}/entities/{entityId}:
+        get:
+            description: ""
+            parameters:
+                - description: Digital twin ID
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+                - description: Entity ID
+                  in: path
+                  name: entityId
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Entity'
+                    description: 200 OK
+                "404":
+                    description: Resource not found
+            summary: Get entity
+            tags:
+                - Digital Twins
+        put:
+            description: ""
+            parameters:
+                - description: Digital twin ID
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+                - description: Entity ID
+                  in: path
+                  name: entityId
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/EntityUpdateRequest'
+                required: true
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Entity'
+                    description: 200 OK
+                "400":
+                    description: Bad request — invalid input
+                "404":
+                    description: Resource not found
+            summary: Update entity
+            tags:
+                - Digital Twins
+    /api/digital-twins/{id}/entities/{entityId}/related:
+        get:
+            description: Returns entities connected to the given entity by a typed relationship traversal.
+            parameters:
+                - description: Digital twin ID
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+                - description: Entity ID
+                  in: path
+                  name: entityId
+                  required: true
+                  schema:
+                    type: string
+                - description: Relationship type to traverse
+                  in: query
+                  name: relationship
+                  required: false
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                items:
+                                    $ref: '#/components/schemas/Entity'
+                                type: array
+                    description: 200 OK
+            summary: Get related entities
+            tags:
+                - Digital Twins
+    /api/digital-twins/{id}/predict:
+        post:
+            description: Runs a single or batch inference using the twin's trained ML models. Provide a top-level 'inputs' array for batch mode; omit it for single-record mode.
+            parameters:
+                - description: Digital twin ID
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/PredictionRequest'
+                required: true
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/PredictionResult'
+                    description: 200 OK
+                "400":
+                    description: Bad request — invalid input
+            summary: Run prediction
+            tags:
+                - Digital Twins
+    /api/digital-twins/{id}/query:
+        post:
+            description: Runs a SPARQL SELECT query against the twin's entity graph.
+            parameters:
+                - description: Digital twin ID
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/QueryRequest'
+                required: true
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/QueryResult'
+                    description: 200 OK
+                "400":
+                    description: Bad request — invalid input
+            summary: Execute SPARQL query
+            tags:
+                - Digital Twins
+    /api/digital-twins/{id}/scenarios:
+        get:
+            description: ""
+            parameters:
+                - description: Digital twin ID
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                items:
+                                    $ref: '#/components/schemas/Scenario'
+                                type: array
+                    description: 200 OK
+            summary: List scenarios
+            tags:
+                - Digital Twins
+        post:
+            description: Defines a what-if scenario by specifying entity attribute modifications. Results are computed in-memory; the live entity graph is never mutated.
+            parameters:
+                - description: Digital twin ID
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/ScenarioCreateRequest'
+                required: true
+            responses:
+                "201":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Scenario'
+                    description: Created
+                "400":
+                    description: Bad request — invalid input
+            summary: Create scenario
+            tags:
+                - Digital Twins
+    /api/digital-twins/{id}/scenarios/{scenarioId}:
+        delete:
+            description: ""
+            parameters:
+                - description: Digital twin ID
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+                - description: Scenario ID
+                  in: path
+                  name: scenarioId
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "204":
+                    description: No content
+                "404":
+                    description: Resource not found
+            summary: Delete scenario
+            tags:
+                - Digital Twins
+        get:
+            description: ""
+            parameters:
+                - description: Digital twin ID
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+                - description: Scenario ID
+                  in: path
+                  name: scenarioId
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Scenario'
+                    description: 200 OK
+                "404":
+                    description: Resource not found
+            summary: Get scenario
+            tags:
+                - Digital Twins
+    /api/digital-twins/{id}/sync:
+        post:
+            description: Pulls the latest records from the twin's linked storage backends and refreshes the entity graph.
+            parameters:
+                - description: Digital twin ID
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                properties:
+                                    status:
+                                        description: '''synced'''
+                                        type: string
+                                type: object
+                    description: 200 OK
+                "404":
+                    description: Resource not found
+            summary: Sync digital twin
+            tags:
+                - Digital Twins
+    /api/extraction/generate-ontology:
+        post:
+            description: Runs the schema-inductive extraction algorithm over the specified storage backends, generates an OWL/Turtle ontology, and diffs it against existing active ontologies. If changes are detected the new ontology is flagged as 'needs_review' and the diff is returned.
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/OntologyExtractionRequest'
+                required: true
+            responses:
+                "201":
+                    content:
+                        application/json:
+                            schema:
+                                properties:
+                                    extraction_summary:
+                                        description: Entity and relationship counts
+                                        type: object
+                                    ontology:
+                                        $ref: '#/components/schemas/Ontology'
+                                    ontology_diff:
+                                        description: Diff against the existing active ontology, if any
+                                        type: object
+                                type: object
+                    description: Created
+                "400":
+                    description: Bad request — invalid input
+            summary: Extract entities and generate ontology
+            tags:
+                - Extraction
+    /api/metrics:
+        get:
+            description: Returns task counts by status and type, plus the current queue depth.
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/MetricsResponse'
+                    description: 200 OK
+            summary: Platform metrics
+            tags:
+                - System
+    /api/ml-models:
+        get:
+            description: Returns all ML models for a project.
+            parameters:
+                - description: Filter by project ID
+                  in: query
+                  name: project_id
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                items:
+                                    $ref: '#/components/schemas/MLModel'
+                                type: array
+                    description: 200 OK
+            summary: List ML models
+            tags:
+                - ML Models
+        post:
+            description: Creates a new ML model record (training must be triggered separately).
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/ModelCreateRequest'
+                required: true
+            responses:
+                "201":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/MLModel'
+                    description: Created
+                "400":
+                    description: Bad request — invalid input
+            summary: Create ML model
+            tags:
+                - ML Models
+    /api/ml-models/{id}:
+        delete:
+            description: ""
+            parameters:
+                - description: Model ID
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "204":
+                    description: No content
+                "404":
+                    description: Resource not found
+            summary: Delete ML model
+            tags:
+                - ML Models
+        get:
+            description: ""
+            parameters:
+                - description: Model ID
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/MLModel'
+                    description: 200 OK
+                "404":
+                    description: Resource not found
+            summary: Get ML model
+            tags:
+                - ML Models
+        put:
+            description: ""
+            parameters:
+                - description: Model ID
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/ModelUpdateRequest'
+                required: true
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/MLModel'
+                    description: 200 OK
+                "400":
+                    description: Bad request — invalid input
+                "404":
+                    description: Resource not found
+            summary: Update ML model
+            tags:
+                - ML Models
+    /api/ml-models/{id}/training/complete:
+        post:
+            description: Called by the worker job to record the trained artifact path and performance metrics.
+            parameters:
+                - description: Model ID
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/TrainingCompleteRequest'
+                required: true
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                properties:
+                                    status:
+                                        description: '''training completed'''
+                                        type: string
+                                type: object
+                    description: 200 OK
+                "400":
+                    description: Bad request — invalid input
+            summary: Report training complete
+            tags:
+                - ML Models
+    /api/ml-models/{id}/training/fail:
+        post:
+            description: Called by the worker job to record a training failure reason.
+            parameters:
+                - description: Model ID
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            properties:
+                                reason:
+                                    description: Failure reason
+                                    type: string
+                            type: object
+                required: true
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                properties:
+                                    status:
+                                        description: '''training failed'''
+                                        type: string
+                                type: object
+                    description: 200 OK
+                "400":
+                    description: Bad request — invalid input
+            summary: Report training failure
+            tags:
+                - ML Models
+    /api/ml-models/recommend:
+        post:
+            description: Analyses the project's ontology and returns a suggested model type (e.g. decision_tree, neural_network) along with a confidence score.
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/ModelRecommendationRequest'
+                required: true
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ModelRecommendation'
+                    description: 200 OK
+                "400":
+                    description: Bad request — invalid input
+            summary: Recommend model type
+            tags:
+                - ML Models
+    /api/ml-models/train:
+        post:
+            description: Enqueues a Kubernetes training job for the specified model. Returns 202 Accepted immediately; poll the model's status field or listen on the WebSocket for completion.
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/ModelTrainingRequest'
+                required: true
+            responses:
+                "202":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/MLModel'
+                    description: Accepted — processing in background
+                "400":
+                    description: Bad request — invalid input
+            summary: Trigger model training
+            tags:
+                - ML Models
+    /api/ontologies:
+        get:
+            description: Returns all ontologies for a project.
+            parameters:
+                - description: Filter by project ID
+                  in: query
+                  name: project_id
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                items:
+                                    $ref: '#/components/schemas/Ontology'
+                                type: array
+                    description: 200 OK
+            summary: List ontologies
+            tags:
+                - Ontologies
+        post:
+            description: Creates a new OWL/Turtle ontology for a project.
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/OntologyCreateRequest'
+                required: true
+            responses:
+                "201":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Ontology'
+                    description: Created
+                "400":
+                    description: Bad request — invalid input
+            summary: Create ontology
+            tags:
+                - Ontologies
+    /api/ontologies/{id}:
+        delete:
+            description: ""
+            parameters:
+                - description: Ontology ID
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "204":
+                    description: No content
+                "404":
+                    description: Resource not found
+            summary: Delete ontology
+            tags:
+                - Ontologies
+        get:
+            description: ""
+            parameters:
+                - description: Ontology ID
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Ontology'
+                    description: 200 OK
+                "404":
+                    description: Resource not found
+            summary: Get ontology
+            tags:
+                - Ontologies
+        put:
+            description: ""
+            parameters:
+                - description: Ontology ID
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/OntologyUpdateRequest'
+                required: true
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Ontology'
+                    description: 200 OK
+                "400":
+                    description: Bad request — invalid input
+                "404":
+                    description: Resource not found
+            summary: Update ontology
+            tags:
+                - Ontologies
+    /api/pipelines:
+        get:
+            description: Returns all pipelines, optionally filtered by project.
+            parameters:
+                - description: Filter by project ID
+                  in: query
+                  name: project_id
+                  required: false
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                items:
+                                    $ref: '#/components/schemas/Pipeline'
+                                type: array
+                    description: 200 OK
+            summary: List pipelines
+            tags:
+                - Pipelines
+        post:
+            description: Creates a new pipeline.
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/PipelineCreateRequest'
+                required: true
+            responses:
+                "201":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Pipeline'
+                    description: Created
+                "400":
+                    description: Bad request — invalid input
+            summary: Create pipeline
+            tags:
+                - Pipelines
+    /api/pipelines/{id}:
+        delete:
+            description: Deletes a pipeline.
+            parameters:
+                - description: Pipeline ID
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "204":
+                    description: No content
+                "404":
+                    description: Resource not found
+            summary: Delete pipeline
+            tags:
+                - Pipelines
+        get:
+            description: Returns a single pipeline by ID.
+            parameters:
+                - description: Pipeline ID
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Pipeline'
+                    description: 200 OK
+                "404":
+                    description: Resource not found
+            summary: Get pipeline
+            tags:
+                - Pipelines
+        put:
+            description: Updates a pipeline's description, steps, or status.
+            parameters:
+                - description: Pipeline ID
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/PipelineUpdateRequest'
+                required: true
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Pipeline'
+                    description: 200 OK
+                "400":
+                    description: Bad request — invalid input
+                "404":
+                    description: Resource not found
+            summary: Update pipeline
+            tags:
+                - Pipelines
+    /api/pipelines/execute:
+        post:
+            description: Enqueues a pipeline for asynchronous execution by a worker.
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/PipelineExecutionRequest'
+                required: true
+            responses:
+                "201":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/WorkTask'
+                    description: Created
+                "400":
+                    description: Bad request — invalid input
+            summary: Execute pipeline
+            tags:
+                - Pipelines
+    /api/plugins:
+        get:
+            description: Returns all installed pipeline step plugins.
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                items:
+                                    $ref: '#/components/schemas/Plugin'
+                                type: array
+                    description: 200 OK
+            summary: List pipeline plugins
+            tags:
+                - Plugins
+        post:
+            description: Installs a pipeline step plugin from a Git repository. Workers clone and compile the plugin at runtime.
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/PluginInstallRequest'
+                required: true
+            responses:
+                "201":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Plugin'
+                    description: Created
+                "400":
+                    description: Bad request — invalid input
+            summary: Install pipeline plugin
+            tags:
+                - Plugins
+    /api/plugins/{name}:
+        delete:
+            description: ""
+            parameters:
+                - description: Plugin name
+                  in: path
+                  name: name
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "204":
+                    description: No content
+                "404":
+                    description: Resource not found
+            summary: Uninstall pipeline plugin
+            tags:
+                - Plugins
+        get:
+            description: ""
+            parameters:
+                - description: Plugin name
+                  in: path
+                  name: name
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Plugin'
+                    description: 200 OK
+                "404":
+                    description: Resource not found
+            summary: Get pipeline plugin
+            tags:
+                - Plugins
+        put:
+            description: Pulls the latest version from the plugin's repository.
+            parameters:
+                - description: Plugin name
+                  in: path
+                  name: name
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/PluginUpdateRequest'
+                required: true
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Plugin'
+                    description: 200 OK
+                "404":
+                    description: Resource not found
+            summary: Update pipeline plugin
+            tags:
+                - Plugins
+    /api/projects:
+        get:
+            description: Returns all projects, optionally filtered by status.
+            parameters:
+                - description: Filter by project status
+                  in: query
+                  name: status
+                  required: false
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                items:
+                                    $ref: '#/components/schemas/Project'
+                                type: array
+                    description: 200 OK
+            summary: List projects
+            tags:
+                - Projects
+        post:
+            description: Creates a new project.
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/ProjectCreateRequest'
+                required: true
+            responses:
+                "201":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Project'
+                    description: Created
+                "400":
+                    description: Bad request — invalid input
+            summary: Create project
+            tags:
+                - Projects
+    /api/projects/{id}:
+        delete:
+            description: Deletes a project and all its components.
+            parameters:
+                - description: Project ID
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "204":
+                    description: No content
+                "404":
+                    description: Resource not found
+            summary: Delete project
+            tags:
+                - Projects
+        get:
+            description: Returns a single project by ID.
+            parameters:
+                - description: Project ID
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Project'
+                    description: 200 OK
+                "404":
+                    description: Resource not found
+            summary: Get project
+            tags:
+                - Projects
+        put:
+            description: Updates a project's name, description, or status.
+            parameters:
+                - description: Project ID
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/ProjectUpdateRequest'
+                required: true
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Project'
+                    description: 200 OK
+                "400":
+                    description: Bad request — invalid input
+                "404":
+                    description: Resource not found
+            summary: Update project
+            tags:
+                - Projects
+    /api/projects/{id}/{componentType}/{componentId}:
+        delete:
+            description: Removes the association between a component and a project.
+            parameters:
+                - description: Project ID
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+                - description: pipelines | ontologies | mlmodels | digitaltwins | storage
+                  in: path
+                  name: componentType
+                  required: true
+                  schema:
+                    type: string
+                - description: Component ID to disassociate
+                  in: path
+                  name: componentId
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "204":
+                    description: No content
+                "400":
+                    description: Bad request — invalid input
+                "404":
+                    description: Resource not found
+            summary: Remove component from project
+            tags:
+                - Projects
+        post:
+            description: Associates a pipeline, ontology, ML model, digital twin, or storage config with a project.
+            parameters:
+                - description: Project ID
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+                - description: pipelines | ontologies | mlmodels | digitaltwins | storage
+                  in: path
+                  name: componentType
+                  required: true
+                  schema:
+                    type: string
+                - description: Component ID to associate
+                  in: path
+                  name: componentId
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "204":
+                    description: No content
+                "400":
+                    description: Bad request — invalid input
+                "404":
+                    description: Resource not found
+            summary: Add component to project
+            tags:
+                - Projects
+    /api/projects/clone:
+        post:
+            description: Deep-clones an existing project including all its pipelines, ontologies, ML models, digital twins, and storage configurations.
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/ProjectCloneRequest'
+                required: true
+            responses:
+                "201":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Project'
+                    description: Created
+                "400":
+                    description: Bad request — invalid input
+                "404":
+                    description: Resource not found
+            summary: Clone project
+            tags:
+                - Projects
+    /api/schedules:
+        get:
+            description: ""
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                items:
+                                    $ref: '#/components/schemas/Schedule'
+                                type: array
+                    description: 200 OK
+            summary: List schedules
+            tags:
+                - Schedules
+        post:
+            description: ""
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/ScheduleCreateRequest'
+                required: true
+            responses:
+                "201":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Schedule'
+                    description: Created
+                "400":
+                    description: Bad request — invalid input
+            summary: Create schedule
+            tags:
+                - Schedules
+    /api/schedules/{id}:
+        delete:
+            description: ""
+            parameters:
+                - description: Schedule ID
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "204":
+                    description: No content
+                "404":
+                    description: Resource not found
+            summary: Delete schedule
+            tags:
+                - Schedules
+        get:
+            description: ""
+            parameters:
+                - description: Schedule ID
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Schedule'
+                    description: 200 OK
+                "404":
+                    description: Resource not found
+            summary: Get schedule
+            tags:
+                - Schedules
+        put:
+            description: ""
+            parameters:
+                - description: Schedule ID
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/ScheduleUpdateRequest'
+                required: true
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Schedule'
+                    description: 200 OK
+                "400":
+                    description: Bad request — invalid input
+                "404":
+                    description: Resource not found
+            summary: Update schedule
+            tags:
+                - Schedules
+    /api/storage-plugins:
+        get:
+            description: Returns all dynamically installed storage backend plugins.
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                items:
+                                    $ref: '#/components/schemas/ExternalStoragePlugin'
+                                type: array
+                    description: 200 OK
+            summary: List storage plugins
+            tags:
+                - Storage Plugins
+        post:
+            description: Clones, compiles, and registers a custom storage backend plugin from a Git repository. The repository must export 'var Plugin' satisfying models.StoragePlugin.
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/ExternalStoragePluginInstallRequest'
+                required: true
+            responses:
+                "201":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ExternalStoragePlugin'
+                    description: Created
+                "400":
+                    description: Bad request — invalid input
+                "422":
+                    description: Processing failed — see error body
+            summary: Install storage plugin
+            tags:
+                - Storage Plugins
+    /api/storage-plugins/{name}:
+        delete:
+            description: 'Removes the plugin from the registry and deletes its cached .so. Note: Go plugins cannot be unloaded from memory; an orchestrator restart is required for full removal.'
+            parameters:
+                - description: Plugin name
+                  in: path
+                  name: name
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "204":
+                    description: No content
+                "404":
+                    description: Resource not found
+            summary: Uninstall storage plugin
+            tags:
+                - Storage Plugins
+        get:
+            description: ""
+            parameters:
+                - description: Plugin name
+                  in: path
+                  name: name
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ExternalStoragePlugin'
+                    description: 200 OK
+                "404":
+                    description: Resource not found
+            summary: Get storage plugin
+            tags:
+                - Storage Plugins
+    /api/storage/{id}/health:
+        get:
+            description: Checks connectivity to the underlying backend for the given storage config ID.
+            parameters:
+                - description: Storage config ID
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                properties:
+                                    error:
+                                        description: Error message if unhealthy
+                                        type: string
+                                    healthy:
+                                        description: Whether the backend is reachable
+                                        type: boolean
+                                type: object
+                    description: 200 OK
+            summary: Storage health check
+            tags:
+                - Storage
+    /api/storage/configs:
+        get:
+            description: Returns all storage configurations for a project.
+            parameters:
+                - description: Filter by project ID
+                  in: query
+                  name: project_id
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                items:
+                                    $ref: '#/components/schemas/StorageConfig'
+                                type: array
+                    description: 200 OK
+            summary: List storage configs
+            tags:
+                - Storage
+        post:
+            description: Creates a new storage backend configuration for a project.
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/StorageConfigCreateRequest'
+                required: true
+            responses:
+                "201":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/StorageConfig'
+                    description: Created
+                "400":
+                    description: Bad request — invalid input
+            summary: Create storage config
+            tags:
+                - Storage
+    /api/storage/configs/{id}:
+        delete:
+            description: ""
+            parameters:
+                - description: Storage config ID
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "204":
+                    description: No content
+                "404":
+                    description: Resource not found
+            summary: Delete storage config
+            tags:
+                - Storage
+        get:
+            description: ""
+            parameters:
+                - description: Storage config ID
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/StorageConfig'
+                    description: 200 OK
+                "404":
+                    description: Resource not found
+            summary: Get storage config
+            tags:
+                - Storage
+        put:
+            description: ""
+            parameters:
+                - description: Storage config ID
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/StorageConfigUpdateRequest'
+                required: true
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/StorageConfig'
+                    description: 200 OK
+                "400":
+                    description: Bad request — invalid input
+                "404":
+                    description: Resource not found
+            summary: Update storage config
+            tags:
+                - Storage
+    /api/storage/delete:
+        post:
+            description: Deletes matching CIR records from the specified storage backend.
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/StorageDeleteRequest'
+                required: true
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/StorageResult'
+                    description: 200 OK
+            summary: Delete CIR data
+            tags:
+                - Storage
+    /api/storage/retrieve:
+        post:
+            description: Queries and returns CIR records from the specified storage backend.
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/StorageQueryRequest'
+                required: true
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                items:
+                                    $ref: '#/components/schemas/CIR'
+                                type: array
+                    description: 200 OK
+            summary: Retrieve CIR data
+            tags:
+                - Storage
+    /api/storage/store:
+        post:
+            description: Writes one or more CIR records to the specified storage backend.
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/StorageStoreRequest'
+                required: true
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/StorageResult'
+                    description: 200 OK
+            summary: Store CIR data
+            tags:
+                - Storage
+    /api/storage/update:
+        post:
+            description: Applies delta updates to matching CIR records in the specified storage backend.
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/StorageUpdateRequest'
+                required: true
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/StorageResult'
+                    description: 200 OK
+            summary: Update CIR data
+            tags:
+                - Storage
+    /api/worktasks:
+        get:
+            description: Returns the current queue depth.
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                properties:
+                                    queue_length:
+                                        description: Number of queued tasks
+                                        type: integer
+                                type: object
+                    description: 200 OK
+            summary: Get queue info
+            tags:
+                - Tasks
+        post:
+            description: 'Submits a new work task to the queue. Requires the worker auth token (Authorization: Bearer <token>).'
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/WorkTaskSubmissionRequest'
+                required: true
+            responses:
+                "201":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/WorkTask'
+                    description: Created
+                "400":
+                    description: Bad request — invalid input
+            summary: Submit work task
+            tags:
+                - Tasks
+    /api/worktasks/{id}:
+        get:
+            description: Returns a work task by ID. Requires the worker auth token.
+            parameters:
+                - description: Work task ID
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/WorkTask'
+                    description: 200 OK
+                "404":
+                    description: Resource not found
+            summary: Get work task
+            tags:
+                - Tasks
+        post:
+            description: Called by workers to report task completion or failure. Requires the worker auth token.
+            parameters:
+                - description: Work task ID
+                  in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/WorkTaskResult'
+                required: true
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                    description: 200 OK
+                "400":
+                    description: Bad request — invalid input
+                "404":
+                    description: Resource not found
+            summary: Update work task status
+            tags:
+                - Tasks
+    /health:
+        get:
+            description: Returns 200 when the orchestrator process is running.
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                properties:
+                                    status:
+                                        description: Always 'healthy'
+                                        type: string
+                                type: object
+                    description: 200 OK
+            summary: Health check
+            tags:
+                - System
+    /openapi.yaml:
+        get:
+            description: Returns the live OpenAPI 3.0 YAML specification, generated dynamically from all registered routes.
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                description: OpenAPI 3.0 YAML document
+                                type: string
+                    description: 200 OK
+            summary: OpenAPI specification
+            tags:
+                - System
+    /ready:
+        get:
+            description: Returns 200 when the queue is accessible and the orchestrator is ready to serve requests.
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                properties:
+                                    status:
+                                        description: '''ready'' or ''not ready'''
+                                        type: string
+                                type: object
+                    description: 200 OK
+                "500":
+                    description: Internal server error
+            summary: Readiness check
+            tags:
+                - System
+servers:
+    - description: Local development
+      url: http://localhost:8080
+tags:
+    - description: Health, readiness, and platform metrics
+      name: System
+    - description: Top-level organisational units
+      name: Projects
+    - description: Ordered processing step sequences
+      name: Pipelines
+    - description: Cron-based pipeline triggers
+      name: Schedules
+    - description: Pipeline step executor plugins (Git-based, dynamic)
+      name: Plugins
+    - description: Storage backend configuration and CIR data operations
+      name: Storage
+    - description: Dynamic storage backend plugins (Git-based, runtime-compiled)
+      name: Storage Plugins
+    - description: OWL/Turtle vocabulary management
+      name: Ontologies
+    - description: Entity extraction and ontology generation from storage data
+      name: Extraction
+    - description: 'ML model lifecycle: create, train, infer, monitor'
+      name: ML Models
+    - description: Live entity graphs with SPARQL querying and scenario analysis
+      name: Digital Twins
+    - description: Work task queue (internal / worker-facing endpoints)
+      name: Tasks

--- a/pkg/api/doc/doc.go
+++ b/pkg/api/doc/doc.go
@@ -1,0 +1,188 @@
+// Package doc provides the OpenAPI route registry for Mimir AIP.
+//
+// Each handler file in pkg/api registers its routes and documentation by
+// calling Register() from an init() function.  The generator at
+// cmd/openapi-gen/main.go imports _ "github.com/mimir-aip/mimir-aip-go/pkg/api"
+// (which triggers every handler's init()) then calls GenerateSpec() to produce
+// the full OpenAPI 3.0 YAML document.
+//
+// To document a new endpoint, add a Register() call inside the handler
+// file's init() function.  No other files need to change — the spec is
+// rebuilt automatically.
+package doc
+
+import (
+	"fmt"
+	"os"
+	"sort"
+
+	"gopkg.in/yaml.v3"
+)
+
+// M is a JSON/YAML object — shorthand used throughout schema definitions.
+type M = map[string]interface{}
+
+// S is a JSON/YAML array.
+type S = []interface{}
+
+// Param describes a single path or query parameter.
+type Param struct {
+	Name        string
+	In          string // "path" | "query"
+	Required    bool
+	Description string
+}
+
+// RouteDoc contains the OpenAPI documentation for one HTTP operation.
+type RouteDoc struct {
+	Summary     string
+	Description string
+	Tags        []string
+	Params      []Param
+	RequestBody M              // nil → no request body
+	Responses   map[string]M   // HTTP status string → response object
+}
+
+// Route is a fully described API endpoint stored in the registry.
+type Route struct {
+	Method string
+	Path   string
+	Doc    RouteDoc
+}
+
+var (
+	routes  []Route
+	schemas M // component schemas, set by RegisterSchemas
+)
+
+// Register adds a route to the global registry.
+// It is safe to call from multiple init() functions.
+func Register(method, path string, doc RouteDoc) {
+	routes = append(routes, Route{Method: method, Path: path, Doc: doc})
+}
+
+// RegisterSchemas sets the component schemas map.
+// Call this once from the schemas init() function.
+func RegisterSchemas(s M) {
+	schemas = s
+}
+
+// GenerateSpec produces the full OpenAPI 3.0 YAML specification.
+func GenerateSpec() (string, error) {
+	// Sort routes for stable output.
+	sorted := make([]Route, len(routes))
+	copy(sorted, routes)
+	sort.Slice(sorted, func(i, j int) bool {
+		if sorted[i].Path != sorted[j].Path {
+			return sorted[i].Path < sorted[j].Path
+		}
+		return sorted[i].Method < sorted[j].Method
+	})
+
+	paths := M{}
+	for _, r := range sorted {
+		if _, ok := paths[r.Path]; !ok {
+			paths[r.Path] = M{}
+		}
+		paths[r.Path].(M)[methodKey(r.Method)] = buildOperation(r)
+	}
+
+	spec := M{
+		"openapi": "3.0.3",
+		"info": M{
+			"title":       "Mimir AIP REST API",
+			"description": "REST API for the Mimir AIP orchestrator. This specification is generated automatically from inline route registrations — it stays in sync with the codebase by construction.",
+			"version":     "0.1.0",
+			"contact": M{
+				"name": "Mimir AIP",
+				"url":  "https://github.com/Mimir-AIP/Mimir-AIP-Go",
+			},
+			"license": M{
+				"name": "See repository",
+				"url":  "https://github.com/Mimir-AIP/Mimir-AIP-Go/blob/main/LICENSE",
+			},
+		},
+		"servers": S{
+			M{"url": "http://localhost:8080", "description": "Local development"},
+		},
+		"tags": S{
+			M{"name": "System", "description": "Health, readiness, and platform metrics"},
+			M{"name": "Projects", "description": "Top-level organisational units"},
+			M{"name": "Pipelines", "description": "Ordered processing step sequences"},
+			M{"name": "Schedules", "description": "Cron-based pipeline triggers"},
+			M{"name": "Plugins", "description": "Pipeline step executor plugins (Git-based, dynamic)"},
+			M{"name": "Storage", "description": "Storage backend configuration and CIR data operations"},
+			M{"name": "Storage Plugins", "description": "Dynamic storage backend plugins (Git-based, runtime-compiled)"},
+			M{"name": "Ontologies", "description": "OWL/Turtle vocabulary management"},
+			M{"name": "Extraction", "description": "Entity extraction and ontology generation from storage data"},
+			M{"name": "ML Models", "description": "ML model lifecycle: create, train, infer, monitor"},
+			M{"name": "Digital Twins", "description": "Live entity graphs with SPARQL querying and scenario analysis"},
+			M{"name": "Tasks", "description": "Work task queue (internal / worker-facing endpoints)"},
+		},
+		"paths":      paths,
+		"components": M{"schemas": schemas},
+	}
+
+	data, err := yaml.Marshal(spec)
+	if err != nil {
+		return "", fmt.Errorf("doc: failed to marshal OpenAPI spec: %w", err)
+	}
+	return string(data), nil
+}
+
+// WriteSpec writes the generated spec to path, creating parent dirs as needed.
+func WriteSpec(path string) error {
+	spec, err := GenerateSpec()
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(path, []byte(spec), 0644); err != nil {
+		return fmt.Errorf("doc: failed to write spec to %s: %w", path, err)
+	}
+	return nil
+}
+
+// ── internal helpers ──────────────────────────────────────────────────────────
+
+func methodKey(m string) string {
+	switch m {
+	case "GET":
+		return "get"
+	case "POST":
+		return "post"
+	case "PUT":
+		return "put"
+	case "DELETE":
+		return "delete"
+	case "PATCH":
+		return "patch"
+	default:
+		return m
+	}
+}
+
+func buildOperation(r Route) M {
+	op := M{
+		"summary":     r.Doc.Summary,
+		"description": r.Doc.Description,
+		"tags":        r.Doc.Tags,
+		"responses":   r.Doc.Responses,
+	}
+	if len(r.Doc.Params) > 0 {
+		params := make(S, 0, len(r.Doc.Params))
+		for _, p := range r.Doc.Params {
+			params = append(params, M{
+				"name":        p.Name,
+				"in":          p.In,
+				"required":    p.Required,
+				"description": p.Description,
+				"schema":      M{"type": "string"},
+			})
+		}
+		op["parameters"] = params
+	}
+	if r.Doc.RequestBody != nil {
+		op["requestBody"] = r.Doc.RequestBody
+	}
+	return op
+}

--- a/pkg/api/doc/helpers.go
+++ b/pkg/api/doc/helpers.go
@@ -1,0 +1,130 @@
+package doc
+
+// ── Schema helpers ────────────────────────────────────────────────────────────
+
+// Ref returns a $ref schema pointing at a named component schema.
+func Ref(name string) M { return M{"$ref": "#/components/schemas/" + name} }
+
+// ArrOf returns an array schema whose items are a $ref to name.
+func ArrOf(name string) M { return M{"type": "array", "items": Ref(name)} }
+
+// Arr returns an array schema with inline item schema.
+func Arr(items M) M { return M{"type": "array", "items": items} }
+
+// Str returns a string schema with description.
+func Str(desc string) M { return M{"type": "string", "description": desc} }
+
+// Bool returns a boolean schema with description.
+func Bool(desc string) M { return M{"type": "boolean", "description": desc} }
+
+// Int returns an integer schema with description.
+func Int(desc string) M { return M{"type": "integer", "description": desc} }
+
+// Obj returns an object schema with description and no fixed properties.
+func Obj(desc string) M { return M{"type": "object", "description": desc} }
+
+// ObjMap returns an object schema with additionalProperties of the given type.
+func ObjMap(valueType string) M {
+	return M{"type": "object", "additionalProperties": M{"type": valueType}}
+}
+
+// Props returns an object schema with explicit properties.
+func Props(required []string, props M) M {
+	s := M{"type": "object", "properties": props}
+	if len(required) > 0 {
+		s["required"] = toS(required)
+	}
+	return s
+}
+
+// ── Parameter helpers ─────────────────────────────────────────────────────────
+
+// PParam returns a required path parameter.
+func PParam(name, desc string) Param {
+	return Param{Name: name, In: "path", Required: true, Description: desc}
+}
+
+// QParam returns a query parameter.
+func QParam(name, desc string, required bool) Param {
+	return Param{Name: name, In: "query", Required: required, Description: desc}
+}
+
+// ── Request body helpers ──────────────────────────────────────────────────────
+
+// JsonBody wraps a schema as an application/json required request body.
+func JsonBody(schema M) M {
+	return M{
+		"required": true,
+		"content":  M{"application/json": M{"schema": schema}},
+	}
+}
+
+// ── Response helpers ──────────────────────────────────────────────────────────
+
+// R merges any number of response maps into one map[string]M.
+func R(maps ...map[string]M) map[string]M {
+	out := map[string]M{}
+	for _, m := range maps {
+		for k, v := range m {
+			out[k] = v
+		}
+	}
+	return out
+}
+
+// OK returns a 200 response with a JSON body schema.
+func OK(schema M) map[string]M {
+	return map[string]M{"200": jsonResp("200 OK", schema)}
+}
+
+// Created returns a 201 response with a JSON body schema.
+func Created(schema M) map[string]M {
+	return map[string]M{"201": jsonResp("Created", schema)}
+}
+
+// NoContent returns a 204 No Content response.
+func NoContent() map[string]M {
+	return map[string]M{"204": {"description": "No content"}}
+}
+
+// NotFound returns a 404 Not Found response.
+func NotFound() map[string]M {
+	return map[string]M{"404": {"description": "Resource not found"}}
+}
+
+// BadRequest returns a 400 Bad Request response.
+func BadRequest() map[string]M {
+	return map[string]M{"400": {"description": "Bad request — invalid input"}}
+}
+
+// Accepted returns a 202 Accepted response with a JSON body schema.
+func Accepted(schema M) map[string]M {
+	return map[string]M{"202": jsonResp("Accepted — processing in background", schema)}
+}
+
+// ServerError returns a 500 Internal Server Error response.
+func ServerError() map[string]M {
+	return map[string]M{"500": {"description": "Internal server error"}}
+}
+
+// Unprocessable returns a 422 response (used for compile failures etc.).
+func Unprocessable() map[string]M {
+	return map[string]M{"422": {"description": "Processing failed — see error body"}}
+}
+
+func jsonResp(desc string, schema M) M {
+	return M{
+		"description": desc,
+		"content":     M{"application/json": M{"schema": schema}},
+	}
+}
+
+// ── Misc ──────────────────────────────────────────────────────────────────────
+
+func toS(ss []string) S {
+	out := make(S, len(ss))
+	for i, s := range ss {
+		out[i] = s
+	}
+	return out
+}

--- a/pkg/api/doc/schemas.go
+++ b/pkg/api/doc/schemas.go
@@ -1,0 +1,387 @@
+package doc
+
+func init() {
+	RegisterSchemas(M{
+		// ── Metrics ──────────────────────────────────────────────────────────
+		"MetricsResponse": Props(nil, M{
+			"queue":           Props(nil, M{"length": Int("Current queue depth")}),
+			"tasks_by_status": ObjMap("integer"),
+			"tasks_by_type":   ObjMap("integer"),
+			"timestamp":       Str("ISO-8601 UTC snapshot timestamp"),
+		}),
+
+		// ── Projects ─────────────────────────────────────────────────────────
+		"Project": Props(nil, M{
+			"id":          Str("Project ID (UUID)"),
+			"name":        Str("Project name"),
+			"description": Str("Project description"),
+			"status":      Str("active | archived"),
+			"components": Props(nil, M{
+				"pipelines":     Arr(M{"type": "string"}),
+				"ontologies":    Arr(M{"type": "string"}),
+				"ml_models":     Arr(M{"type": "string"}),
+				"digital_twins": Arr(M{"type": "string"}),
+				"storage":       Arr(M{"type": "string"}),
+			}),
+			"created_at": Str("ISO-8601 creation timestamp"),
+			"updated_at": Str("ISO-8601 last-updated timestamp"),
+		}),
+		"ProjectCreateRequest": Props([]string{"name"}, M{
+			"name":        Str("Project name"),
+			"description": Str("Project description"),
+		}),
+		"ProjectUpdateRequest": Props(nil, M{
+			"name":        Str("New name"),
+			"description": Str("New description"),
+			"status":      Str("New status"),
+		}),
+		"ProjectCloneRequest": Props([]string{"project_id", "name"}, M{
+			"project_id": Str("ID of the project to clone"),
+			"name":       Str("Name for the cloned project"),
+		}),
+
+		// ── Pipelines ────────────────────────────────────────────────────────
+		"Pipeline": Props(nil, M{
+			"id":          Str("Pipeline ID (UUID)"),
+			"project_id":  Str("Owning project ID"),
+			"name":        Str("Pipeline name"),
+			"type":        Str("ingestion | processing | output"),
+			"description": Str("Pipeline description"),
+			"steps":       ArrOf("PipelineStep"),
+			"status":      Str("Pipeline status"),
+			"created_at":  Str("ISO-8601 creation timestamp"),
+			"updated_at":  Str("ISO-8601 last-updated timestamp"),
+		}),
+		"PipelineStep": Props([]string{"name", "plugin", "action"}, M{
+			"name":       Str("Step name (unique within pipeline)"),
+			"plugin":     Str("Plugin name or 'default' for built-in actions"),
+			"action":     Str("Action name within the plugin"),
+			"parameters": M{"type": "object", "additionalProperties": true},
+			"output":     ObjMap("string"),
+		}),
+		"PipelineCreateRequest": Props([]string{"project_id", "name", "type", "steps"}, M{
+			"project_id":  Str("Owning project ID"),
+			"name":        Str("Pipeline name"),
+			"type":        Str("Pipeline type"),
+			"description": Str("Pipeline description"),
+			"steps":       ArrOf("PipelineStep"),
+		}),
+		"PipelineUpdateRequest": Props(nil, M{
+			"description": Str("New description"),
+			"steps":       ArrOf("PipelineStep"),
+			"status":      Str("New status"),
+		}),
+		"PipelineExecutionRequest": Props([]string{"pipeline_id"}, M{
+			"pipeline_id":  Str("Pipeline ID to execute"),
+			"trigger_type": Str("manual | scheduled | automatic"),
+			"triggered_by": Str("Trigger source identifier"),
+			"parameters":   M{"type": "object", "additionalProperties": true},
+		}),
+
+		// ── Schedules ─────────────────────────────────────────────────────────
+		"Schedule": Props(nil, M{
+			"id":           Str("Schedule ID (UUID)"),
+			"name":         Str("Schedule name"),
+			"cron":         Str("Cron expression (e.g. '0 * * * *')"),
+			"pipeline_ids": Arr(M{"type": "string"}),
+			"enabled":      Bool("Whether the schedule is active"),
+			"created_at":   Str("ISO-8601 creation timestamp"),
+			"updated_at":   Str("ISO-8601 last-updated timestamp"),
+		}),
+		"ScheduleCreateRequest": Props([]string{"name", "cron", "pipeline_ids"}, M{
+			"name":         Str("Schedule name"),
+			"cron":         Str("Cron expression"),
+			"pipeline_ids": Arr(M{"type": "string"}),
+			"enabled":      Bool("Start enabled (default true)"),
+		}),
+		"ScheduleUpdateRequest": Props(nil, M{
+			"name":         Str("New name"),
+			"cron":         Str("New cron expression"),
+			"pipeline_ids": Arr(M{"type": "string"}),
+			"enabled":      Bool("Enable or disable"),
+		}),
+
+		// ── Pipeline Plugins ─────────────────────────────────────────────────
+		"Plugin": Props(nil, M{
+			"name":           Str("Plugin name"),
+			"version":        Str("Plugin version"),
+			"description":    Str("Plugin description"),
+			"author":         Str("Plugin author"),
+			"repository_url": Str("Git repository URL"),
+			"actions":        Arr(M{"type": "string"}),
+			"installed_at":   Str("ISO-8601 installation timestamp"),
+		}),
+		"PluginInstallRequest": Props([]string{"repository_url"}, M{
+			"repository_url": Str("HTTPS Git URL of the plugin repository"),
+			"git_ref":        Str("Branch, tag, or commit SHA (default: main)"),
+		}),
+		"PluginUpdateRequest": Props(nil, M{
+			"git_ref": Str("Branch, tag, or commit SHA to update to"),
+		}),
+
+		// ── Storage ──────────────────────────────────────────────────────────
+		"StorageConfig": Props(nil, M{
+			"id":          Str("Storage config ID (UUID)"),
+			"project_id":  Str("Owning project ID"),
+			"plugin_type": Str("filesystem | postgresql | mysql | mongodb | s3 | redis | elasticsearch | neo4j | <custom>"),
+			"config":      M{"type": "object", "additionalProperties": true},
+			"ontology_id": Str("Optional linked ontology ID"),
+			"active":      Bool("Whether this config is active"),
+			"created_at":  Str("ISO-8601 creation timestamp"),
+			"updated_at":  Str("ISO-8601 last-updated timestamp"),
+		}),
+		"StorageConfigCreateRequest": Props([]string{"project_id", "plugin_type", "config"}, M{
+			"project_id":  Str("Owning project ID"),
+			"plugin_type": Str("Backend type"),
+			"config":      M{"type": "object", "additionalProperties": true},
+			"ontology_id": Str("Optional linked ontology ID"),
+		}),
+		"StorageConfigUpdateRequest": Props(nil, M{
+			"config":      M{"type": "object", "additionalProperties": true},
+			"ontology_id": Str("Linked ontology ID"),
+			"active":      Bool("Active flag"),
+		}),
+		"CIR": M{
+			"description": "Common Internal Representation — the normalised record format used across all storage backends.",
+			"type":        "object",
+			"properties": M{
+				"id":       Str("CIR record ID"),
+				"source":   M{"type": "object", "additionalProperties": true, "description": "Provenance information"},
+				"data":     M{"type": "object", "additionalProperties": true, "description": "Record payload"},
+				"metadata": M{"type": "object", "additionalProperties": true, "description": "Record metadata"},
+			},
+		},
+		"CIRQuery": Props(nil, M{
+			"entity_type": Str("Filter by entity type"),
+			"filters":     ArrOf("CIRCondition"),
+			"order_by":    ArrOf("OrderByClause"),
+			"limit":       Int("Maximum results"),
+			"offset":      Int("Pagination offset"),
+		}),
+		"CIRCondition": Props([]string{"attribute", "operator", "value"}, M{
+			"attribute": Str("Attribute name"),
+			"operator":  Str("eq | neq | gt | gte | lt | lte | in | like"),
+			"value":     M{"description": "Filter value"},
+		}),
+		"OrderByClause": Props([]string{"attribute"}, M{
+			"attribute": Str("Attribute to sort by"),
+			"direction": Str("asc | desc (default asc)"),
+		}),
+		"StorageResult": Props(nil, M{
+			"success":        Bool("Whether the operation succeeded"),
+			"affected_items": Int("Number of records affected"),
+			"error":          Str("Error message if unsuccessful"),
+		}),
+		"StorageStoreRequest": Props([]string{"project_id", "storage_id", "cir_data"}, M{
+			"project_id": Str("Project ID"),
+			"storage_id": Str("Storage config ID"),
+			"cir_data":   Ref("CIR"),
+		}),
+		"StorageQueryRequest": Props([]string{"project_id", "storage_id"}, M{
+			"project_id": Str("Project ID"),
+			"storage_id": Str("Storage config ID"),
+			"query":      Ref("CIRQuery"),
+		}),
+		"StorageUpdateRequest": Props([]string{"project_id", "storage_id", "query", "updates"}, M{
+			"project_id": Str("Project ID"),
+			"storage_id": Str("Storage config ID"),
+			"query":      Ref("CIRQuery"),
+			"updates": Props(nil, M{
+				"filters": ArrOf("CIRCondition"),
+				"updates": M{"type": "object", "additionalProperties": true},
+			}),
+		}),
+		"StorageDeleteRequest": Props([]string{"project_id", "storage_id", "query"}, M{
+			"project_id": Str("Project ID"),
+			"storage_id": Str("Storage config ID"),
+			"query":      Ref("CIRQuery"),
+		}),
+
+		// ── Storage Plugins (dynamic) ─────────────────────────────────────────
+		"ExternalStoragePlugin": Props(nil, M{
+			"name":            Str("Plugin name (derived from repository URL)"),
+			"version":         Str("Version from plugin.yaml"),
+			"description":     Str("Description from plugin.yaml"),
+			"author":          Str("Author from plugin.yaml"),
+			"repository_url":  Str("Git repository URL"),
+			"git_commit_hash": Str("Commit SHA the current .so was compiled from"),
+			"status":          Str("active | error"),
+			"error_message":   Str("Compilation or load error, if status=error"),
+			"installed_at":    Str("ISO-8601 installation timestamp"),
+			"updated_at":      Str("ISO-8601 last-updated timestamp"),
+		}),
+		"ExternalStoragePluginInstallRequest": Props([]string{"repository_url"}, M{
+			"repository_url": Str("HTTPS Git URL of the storage plugin repository"),
+			"git_ref":        Str("Branch, tag, or commit SHA (default: main)"),
+		}),
+
+		// ── Ontologies ────────────────────────────────────────────────────────
+		"Ontology": Props(nil, M{
+			"id":          Str("Ontology ID (UUID)"),
+			"project_id":  Str("Owning project ID"),
+			"name":        Str("Ontology name"),
+			"description": Str("Ontology description"),
+			"content":     Str("OWL/Turtle ontology content"),
+			"status":      Str("draft | active | needs_review | deprecated"),
+			"created_at":  Str("ISO-8601 creation timestamp"),
+			"updated_at":  Str("ISO-8601 last-updated timestamp"),
+		}),
+		"OntologyCreateRequest": Props([]string{"project_id", "name"}, M{
+			"project_id":  Str("Owning project ID"),
+			"name":        Str("Ontology name"),
+			"description": Str("Description"),
+			"content":     Str("Initial OWL/Turtle content"),
+		}),
+		"OntologyUpdateRequest": Props(nil, M{
+			"name":        Str("New name"),
+			"description": Str("New description"),
+			"content":     Str("Updated OWL/Turtle content"),
+			"status":      Str("New status"),
+		}),
+
+		// ── Extraction ────────────────────────────────────────────────────────
+		"ExtractionRequest": Props([]string{"project_id", "storage_id"}, M{
+			"project_id":  Str("Project ID"),
+			"storage_id":  Str("Storage config ID to extract from"),
+			"ontology_id": Str("Existing ontology to diff against (optional)"),
+		}),
+		"ExtractionResult": Props(nil, M{
+			"ontology":     Ref("Ontology"),
+			"diff":         Obj("OntologyDiff — added/removed/modified classes and properties"),
+			"needs_review": Bool("True if the diff is significant enough to flag for human review"),
+		}),
+
+		// ── ML Models ─────────────────────────────────────────────────────────
+		"MLModel": Props(nil, M{
+			"id":                   Str("ML model ID (UUID)"),
+			"project_id":           Str("Owning project ID"),
+			"ontology_id":          Str("Linked ontology ID"),
+			"name":                 Str("Model name"),
+			"description":          Str("Model description"),
+			"type":                 Str("decision_tree | random_forest | regression | neural_network"),
+			"status":               Str("draft | training | trained | failed | degraded | deprecated | archived"),
+			"version":              Str("Model version string"),
+			"is_recommended":       Bool("True if recommended by the recommendation engine"),
+			"recommendation_score": Int("Recommendation engine score"),
+			"training_config":      Obj("Training configuration"),
+			"training_metrics":     Obj("Metrics recorded during training"),
+			"model_artifact_path":  Str("Path to the serialised model artifact"),
+			"performance_metrics":  Obj("Latest performance metrics"),
+			"metadata":             M{"type": "object", "additionalProperties": true},
+			"created_at":           Str("ISO-8601 creation timestamp"),
+			"updated_at":           Str("ISO-8601 last-updated timestamp"),
+		}),
+		"MLModelCreateRequest": Props([]string{"project_id", "name", "type"}, M{
+			"project_id":      Str("Owning project ID"),
+			"ontology_id":     Str("Linked ontology ID"),
+			"name":            Str("Model name"),
+			"description":     Str("Description"),
+			"type":            Str("Model type"),
+			"training_config": Obj("Training configuration"),
+		}),
+		"MLModelUpdateRequest": Props(nil, M{
+			"name":            Str("New name"),
+			"description":     Str("New description"),
+			"training_config": Obj("Updated training configuration"),
+			"status":          Str("New status"),
+		}),
+		"MLModelRecommendRequest": Props([]string{"project_id"}, M{
+			"project_id":  Str("Project ID"),
+			"ontology_id": Str("Ontology to base recommendation on"),
+			"storage_id":  Str("Storage config to sample data from"),
+		}),
+		"MLModelRecommendation": Props(nil, M{
+			"recommended_type": Str("Recommended model type"),
+			"score":            Int("Confidence score (0-100)"),
+			"reason":           Str("Explanation"),
+			"alternatives":     Arr(Obj("Alternative model type with score and reason")),
+		}),
+		"MLTrainingRequest": Props([]string{"model_id"}, M{
+			"model_id":   Str("ID of the model to train"),
+			"storage_id": Str("Storage config to load training data from"),
+		}),
+
+		// ── Digital Twins ─────────────────────────────────────────────────────
+		"DigitalTwin": Props(nil, M{
+			"id":           Str("Digital twin ID (UUID)"),
+			"project_id":   Str("Owning project ID"),
+			"name":         Str("Digital twin name"),
+			"description":  Str("Description"),
+			"ontology_id":  Str("Linked ontology ID"),
+			"status":       Str("initialising | active | syncing | error"),
+			"entity_count": Int("Number of entities in the graph"),
+			"metadata":     M{"type": "object", "additionalProperties": true},
+			"created_at":   Str("ISO-8601 creation timestamp"),
+			"updated_at":   Str("ISO-8601 last-updated timestamp"),
+		}),
+		"DigitalTwinCreateRequest": Props([]string{"project_id", "name"}, M{
+			"project_id":  Str("Owning project ID"),
+			"ontology_id": Str("Linked ontology ID"),
+			"name":        Str("Digital twin name"),
+			"description": Str("Description"),
+		}),
+		"DigitalTwinUpdateRequest": Props(nil, M{
+			"name":        Str("New name"),
+			"description": Str("New description"),
+			"ontology_id": Str("New linked ontology ID"),
+		}),
+		"Entity": Props(nil, M{
+			"id":             Str("Entity ID (UUID)"),
+			"type":           Str("Entity type (from ontology)"),
+			"attributes":     M{"type": "object", "additionalProperties": true},
+			"computed_values": M{"type": "object", "additionalProperties": true},
+			"relationships":  Arr(Obj("Relationship to another entity")),
+			"last_updated":   Str("ISO-8601 last-updated timestamp"),
+		}),
+		"ScenarioRequest": Props([]string{"modifications"}, M{
+			"scenario_id":   Str("Optional scenario ID (generated if omitted)"),
+			"modifications": Arr(Obj("Entity attribute modification")),
+		}),
+		"ScenarioResult": Props(nil, M{
+			"scenario_id": Str("Scenario ID"),
+			"entities":    ArrOf("Entity"),
+			"predictions": M{"type": "object", "additionalProperties": true},
+			"created_at":  Str("ISO-8601 timestamp"),
+		}),
+		"ActionRequest": Props([]string{"action_type"}, M{
+			"action_type": Str("Type of action to apply"),
+			"parameters":  M{"type": "object", "additionalProperties": true},
+		}),
+		"ActionResult": Props(nil, M{
+			"action_id":  Str("Action ID"),
+			"status":     Str("Action status"),
+			"result":     M{"type": "object", "additionalProperties": true},
+			"applied_at": Str("ISO-8601 timestamp"),
+		}),
+
+		// ── Work Tasks ────────────────────────────────────────────────────────
+		"WorkTask": Props(nil, M{
+			"id":                    Str("Work task ID (UUID)"),
+			"type":                  Str("pipeline_execution | ml_training | ml_inference | digital_twin_update"),
+			"status":                Str("queued | running | completed | failed"),
+			"priority":              Int("Task priority (higher = processed first)"),
+			"project_id":            Str("Owning project ID"),
+			"submitted_at":          Str("ISO-8601 submission timestamp"),
+			"started_at":            Str("ISO-8601 start timestamp"),
+			"completed_at":          Str("ISO-8601 completion timestamp"),
+			"error_message":         Str("Error message if task failed"),
+			"retry_count":           Int("Number of retries so far"),
+			"max_retries":           Int("Maximum retry attempts"),
+			"task_spec":             M{"type": "object", "additionalProperties": true},
+			"resource_requirements": M{"type": "object", "additionalProperties": true},
+		}),
+		"WorkTaskSubmissionRequest": Props([]string{"type", "project_id"}, M{
+			"type":                  Str("Task type"),
+			"project_id":            Str("Owning project ID"),
+			"priority":              Int("Task priority"),
+			"task_spec":             M{"type": "object", "additionalProperties": true},
+			"resource_requirements": M{"type": "object", "additionalProperties": true},
+			"data_access":           M{"type": "object", "additionalProperties": true},
+		}),
+		"WorkTaskResult": Props([]string{"status"}, M{
+			"status":        Str("completed | failed"),
+			"error_message": Str("Error message if failed"),
+			"result":        M{"type": "object", "additionalProperties": true},
+		}),
+	})
+}

--- a/pkg/api/routes_digitaltwins.go
+++ b/pkg/api/routes_digitaltwins.go
@@ -1,0 +1,175 @@
+package api
+
+import "github.com/mimir-aip/mimir-aip-go/pkg/api/doc"
+
+func init() {
+	// ── Digital Twins ──────────────────────────────────────────────────────────
+	doc.Register("GET", "/api/digital-twins", doc.RouteDoc{
+		Summary:     "List digital twins",
+		Description: "Returns all digital twins for a project.",
+		Tags:        []string{"Digital Twins"},
+		Params:      []doc.Param{doc.QParam("project_id", "Filter by project ID", true)},
+		Responses:   doc.R(doc.OK(doc.ArrOf("DigitalTwin"))),
+	})
+	doc.Register("POST", "/api/digital-twins", doc.RouteDoc{
+		Summary:     "Create digital twin",
+		Description: "Creates a new digital twin and initialises its entity graph from the associated ontology.",
+		Tags:        []string{"Digital Twins"},
+		RequestBody: doc.JsonBody(doc.Ref("DigitalTwinCreateRequest")),
+		Responses:   doc.R(doc.Created(doc.Ref("DigitalTwin")), doc.BadRequest()),
+	})
+	doc.Register("GET", "/api/digital-twins/{id}", doc.RouteDoc{
+		Summary:   "Get digital twin",
+		Tags:      []string{"Digital Twins"},
+		Params:    []doc.Param{doc.PParam("id", "Digital twin ID")},
+		Responses: doc.R(doc.OK(doc.Ref("DigitalTwin")), doc.NotFound()),
+	})
+	doc.Register("PUT", "/api/digital-twins/{id}", doc.RouteDoc{
+		Summary:     "Update digital twin",
+		Tags:        []string{"Digital Twins"},
+		Params:      []doc.Param{doc.PParam("id", "Digital twin ID")},
+		RequestBody: doc.JsonBody(doc.Ref("DigitalTwinUpdateRequest")),
+		Responses:   doc.R(doc.OK(doc.Ref("DigitalTwin")), doc.BadRequest(), doc.NotFound()),
+	})
+	doc.Register("DELETE", "/api/digital-twins/{id}", doc.RouteDoc{
+		Summary:   "Delete digital twin",
+		Tags:      []string{"Digital Twins"},
+		Params:    []doc.Param{doc.PParam("id", "Digital twin ID")},
+		Responses: doc.R(doc.NoContent(), doc.NotFound()),
+	})
+
+	// ── Sync ───────────────────────────────────────────────────────────────────
+	doc.Register("POST", "/api/digital-twins/{id}/sync", doc.RouteDoc{
+		Summary:     "Sync digital twin",
+		Description: "Pulls the latest records from the twin's linked storage backends and refreshes the entity graph.",
+		Tags:        []string{"Digital Twins"},
+		Params:      []doc.Param{doc.PParam("id", "Digital twin ID")},
+		Responses:   doc.R(doc.OK(doc.Props(nil, doc.M{"status": doc.Str("'synced'")})), doc.NotFound()),
+	})
+
+	// ── Entities ───────────────────────────────────────────────────────────────
+	doc.Register("GET", "/api/digital-twins/{id}/entities", doc.RouteDoc{
+		Summary:   "List entities",
+		Tags:      []string{"Digital Twins"},
+		Params:    []doc.Param{doc.PParam("id", "Digital twin ID")},
+		Responses: doc.R(doc.OK(doc.ArrOf("Entity"))),
+	})
+	doc.Register("GET", "/api/digital-twins/{id}/entities/{entityId}", doc.RouteDoc{
+		Summary: "Get entity",
+		Tags:    []string{"Digital Twins"},
+		Params: []doc.Param{
+			doc.PParam("id", "Digital twin ID"),
+			doc.PParam("entityId", "Entity ID"),
+		},
+		Responses: doc.R(doc.OK(doc.Ref("Entity")), doc.NotFound()),
+	})
+	doc.Register("PUT", "/api/digital-twins/{id}/entities/{entityId}", doc.RouteDoc{
+		Summary: "Update entity",
+		Tags:    []string{"Digital Twins"},
+		Params: []doc.Param{
+			doc.PParam("id", "Digital twin ID"),
+			doc.PParam("entityId", "Entity ID"),
+		},
+		RequestBody: doc.JsonBody(doc.Ref("EntityUpdateRequest")),
+		Responses:   doc.R(doc.OK(doc.Ref("Entity")), doc.BadRequest(), doc.NotFound()),
+	})
+	doc.Register("GET", "/api/digital-twins/{id}/entities/{entityId}/related", doc.RouteDoc{
+		Summary:     "Get related entities",
+		Description: "Returns entities connected to the given entity by a typed relationship traversal.",
+		Tags:        []string{"Digital Twins"},
+		Params: []doc.Param{
+			doc.PParam("id", "Digital twin ID"),
+			doc.PParam("entityId", "Entity ID"),
+			doc.QParam("relationship", "Relationship type to traverse", false),
+		},
+		Responses: doc.R(doc.OK(doc.ArrOf("Entity"))),
+	})
+
+	// ── SPARQL Query ───────────────────────────────────────────────────────────
+	doc.Register("POST", "/api/digital-twins/{id}/query", doc.RouteDoc{
+		Summary:     "Execute SPARQL query",
+		Description: "Runs a SPARQL SELECT query against the twin's entity graph.",
+		Tags:        []string{"Digital Twins"},
+		Params:      []doc.Param{doc.PParam("id", "Digital twin ID")},
+		RequestBody: doc.JsonBody(doc.Ref("QueryRequest")),
+		Responses:   doc.R(doc.OK(doc.Ref("QueryResult")), doc.BadRequest()),
+	})
+
+	// ── Prediction ─────────────────────────────────────────────────────────────
+	doc.Register("POST", "/api/digital-twins/{id}/predict", doc.RouteDoc{
+		Summary:     "Run prediction",
+		Description: "Runs a single or batch inference using the twin's trained ML models. Provide a top-level 'inputs' array for batch mode; omit it for single-record mode.",
+		Tags:        []string{"Digital Twins"},
+		Params:      []doc.Param{doc.PParam("id", "Digital twin ID")},
+		RequestBody: doc.JsonBody(doc.Ref("PredictionRequest")),
+		Responses:   doc.R(doc.OK(doc.Ref("PredictionResult")), doc.BadRequest()),
+	})
+
+	// ── Scenarios ──────────────────────────────────────────────────────────────
+	doc.Register("GET", "/api/digital-twins/{id}/scenarios", doc.RouteDoc{
+		Summary:   "List scenarios",
+		Tags:      []string{"Digital Twins"},
+		Params:    []doc.Param{doc.PParam("id", "Digital twin ID")},
+		Responses: doc.R(doc.OK(doc.ArrOf("Scenario"))),
+	})
+	doc.Register("POST", "/api/digital-twins/{id}/scenarios", doc.RouteDoc{
+		Summary:     "Create scenario",
+		Description: "Defines a what-if scenario by specifying entity attribute modifications. Results are computed in-memory; the live entity graph is never mutated.",
+		Tags:        []string{"Digital Twins"},
+		Params:      []doc.Param{doc.PParam("id", "Digital twin ID")},
+		RequestBody: doc.JsonBody(doc.Ref("ScenarioCreateRequest")),
+		Responses:   doc.R(doc.Created(doc.Ref("Scenario")), doc.BadRequest()),
+	})
+	doc.Register("GET", "/api/digital-twins/{id}/scenarios/{scenarioId}", doc.RouteDoc{
+		Summary: "Get scenario",
+		Tags:    []string{"Digital Twins"},
+		Params: []doc.Param{
+			doc.PParam("id", "Digital twin ID"),
+			doc.PParam("scenarioId", "Scenario ID"),
+		},
+		Responses: doc.R(doc.OK(doc.Ref("Scenario")), doc.NotFound()),
+	})
+	doc.Register("DELETE", "/api/digital-twins/{id}/scenarios/{scenarioId}", doc.RouteDoc{
+		Summary: "Delete scenario",
+		Tags:    []string{"Digital Twins"},
+		Params: []doc.Param{
+			doc.PParam("id", "Digital twin ID"),
+			doc.PParam("scenarioId", "Scenario ID"),
+		},
+		Responses: doc.R(doc.NoContent(), doc.NotFound()),
+	})
+
+	// ── Actions ────────────────────────────────────────────────────────────────
+	doc.Register("GET", "/api/digital-twins/{id}/actions", doc.RouteDoc{
+		Summary:   "List actions",
+		Tags:      []string{"Digital Twins"},
+		Params:    []doc.Param{doc.PParam("id", "Digital twin ID")},
+		Responses: doc.R(doc.OK(doc.ArrOf("Action"))),
+	})
+	doc.Register("POST", "/api/digital-twins/{id}/actions", doc.RouteDoc{
+		Summary:     "Create action",
+		Description: "Registers an action that can be applied to entities within the digital twin.",
+		Tags:        []string{"Digital Twins"},
+		Params:      []doc.Param{doc.PParam("id", "Digital twin ID")},
+		RequestBody: doc.JsonBody(doc.Ref("ActionCreateRequest")),
+		Responses:   doc.R(doc.Created(doc.Ref("Action")), doc.BadRequest()),
+	})
+	doc.Register("GET", "/api/digital-twins/{id}/actions/{actionId}", doc.RouteDoc{
+		Summary: "Get action",
+		Tags:    []string{"Digital Twins"},
+		Params: []doc.Param{
+			doc.PParam("id", "Digital twin ID"),
+			doc.PParam("actionId", "Action ID"),
+		},
+		Responses: doc.R(doc.OK(doc.Ref("Action")), doc.NotFound()),
+	})
+	doc.Register("DELETE", "/api/digital-twins/{id}/actions/{actionId}", doc.RouteDoc{
+		Summary: "Delete action",
+		Tags:    []string{"Digital Twins"},
+		Params: []doc.Param{
+			doc.PParam("id", "Digital twin ID"),
+			doc.PParam("actionId", "Action ID"),
+		},
+		Responses: doc.R(doc.NoContent(), doc.NotFound()),
+	})
+}

--- a/pkg/api/routes_mlmodels.go
+++ b/pkg/api/routes_mlmodels.go
@@ -1,0 +1,74 @@
+package api
+
+import "github.com/mimir-aip/mimir-aip-go/pkg/api/doc"
+
+func init() {
+	// ── ML Models ──────────────────────────────────────────────────────────────
+	doc.Register("GET", "/api/ml-models", doc.RouteDoc{
+		Summary:     "List ML models",
+		Description: "Returns all ML models for a project.",
+		Tags:        []string{"ML Models"},
+		Params:      []doc.Param{doc.QParam("project_id", "Filter by project ID", true)},
+		Responses:   doc.R(doc.OK(doc.ArrOf("MLModel"))),
+	})
+	doc.Register("POST", "/api/ml-models", doc.RouteDoc{
+		Summary:     "Create ML model",
+		Description: "Creates a new ML model record (training must be triggered separately).",
+		Tags:        []string{"ML Models"},
+		RequestBody: doc.JsonBody(doc.Ref("ModelCreateRequest")),
+		Responses:   doc.R(doc.Created(doc.Ref("MLModel")), doc.BadRequest()),
+	})
+	doc.Register("GET", "/api/ml-models/{id}", doc.RouteDoc{
+		Summary:   "Get ML model",
+		Tags:      []string{"ML Models"},
+		Params:    []doc.Param{doc.PParam("id", "Model ID")},
+		Responses: doc.R(doc.OK(doc.Ref("MLModel")), doc.NotFound()),
+	})
+	doc.Register("PUT", "/api/ml-models/{id}", doc.RouteDoc{
+		Summary:     "Update ML model",
+		Tags:        []string{"ML Models"},
+		Params:      []doc.Param{doc.PParam("id", "Model ID")},
+		RequestBody: doc.JsonBody(doc.Ref("ModelUpdateRequest")),
+		Responses:   doc.R(doc.OK(doc.Ref("MLModel")), doc.BadRequest(), doc.NotFound()),
+	})
+	doc.Register("DELETE", "/api/ml-models/{id}", doc.RouteDoc{
+		Summary:   "Delete ML model",
+		Tags:      []string{"ML Models"},
+		Params:    []doc.Param{doc.PParam("id", "Model ID")},
+		Responses: doc.R(doc.NoContent(), doc.NotFound()),
+	})
+
+	// ── Training Actions ───────────────────────────────────────────────────────
+	doc.Register("POST", "/api/ml-models/train", doc.RouteDoc{
+		Summary:     "Trigger model training",
+		Description: "Enqueues a Kubernetes training job for the specified model. Returns 202 Accepted immediately; poll the model's status field or listen on the WebSocket for completion.",
+		Tags:        []string{"ML Models"},
+		RequestBody: doc.JsonBody(doc.Ref("ModelTrainingRequest")),
+		Responses:   doc.R(doc.Accepted(doc.Ref("MLModel")), doc.BadRequest()),
+	})
+	doc.Register("POST", "/api/ml-models/recommend", doc.RouteDoc{
+		Summary:     "Recommend model type",
+		Description: "Analyses the project's ontology and returns a suggested model type (e.g. decision_tree, neural_network) along with a confidence score.",
+		Tags:        []string{"ML Models"},
+		RequestBody: doc.JsonBody(doc.Ref("ModelRecommendationRequest")),
+		Responses:   doc.R(doc.OK(doc.Ref("ModelRecommendation")), doc.BadRequest()),
+	})
+
+	// ── Worker Callbacks (called by Kubernetes training jobs) ──────────────────
+	doc.Register("POST", "/api/ml-models/{id}/training/complete", doc.RouteDoc{
+		Summary:     "Report training complete",
+		Description: "Called by the worker job to record the trained artifact path and performance metrics.",
+		Tags:        []string{"ML Models"},
+		Params:      []doc.Param{doc.PParam("id", "Model ID")},
+		RequestBody: doc.JsonBody(doc.Ref("TrainingCompleteRequest")),
+		Responses:   doc.R(doc.OK(doc.Props(nil, doc.M{"status": doc.Str("'training completed'")})), doc.BadRequest()),
+	})
+	doc.Register("POST", "/api/ml-models/{id}/training/fail", doc.RouteDoc{
+		Summary:     "Report training failure",
+		Description: "Called by the worker job to record a training failure reason.",
+		Tags:        []string{"ML Models"},
+		Params:      []doc.Param{doc.PParam("id", "Model ID")},
+		RequestBody: doc.JsonBody(doc.Props(nil, doc.M{"reason": doc.Str("Failure reason")})),
+		Responses:   doc.R(doc.OK(doc.Props(nil, doc.M{"status": doc.Str("'training failed'")})), doc.BadRequest()),
+	})
+}

--- a/pkg/api/routes_ontologies.go
+++ b/pkg/api/routes_ontologies.go
@@ -1,0 +1,53 @@
+package api
+
+import "github.com/mimir-aip/mimir-aip-go/pkg/api/doc"
+
+func init() {
+	// ── Ontologies ─────────────────────────────────────────────────────────────
+	doc.Register("GET", "/api/ontologies", doc.RouteDoc{
+		Summary:     "List ontologies",
+		Description: "Returns all ontologies for a project.",
+		Tags:        []string{"Ontologies"},
+		Params:      []doc.Param{doc.QParam("project_id", "Filter by project ID", true)},
+		Responses:   doc.R(doc.OK(doc.ArrOf("Ontology"))),
+	})
+	doc.Register("POST", "/api/ontologies", doc.RouteDoc{
+		Summary:     "Create ontology",
+		Description: "Creates a new OWL/Turtle ontology for a project.",
+		Tags:        []string{"Ontologies"},
+		RequestBody: doc.JsonBody(doc.Ref("OntologyCreateRequest")),
+		Responses:   doc.R(doc.Created(doc.Ref("Ontology")), doc.BadRequest()),
+	})
+	doc.Register("GET", "/api/ontologies/{id}", doc.RouteDoc{
+		Summary:   "Get ontology",
+		Tags:      []string{"Ontologies"},
+		Params:    []doc.Param{doc.PParam("id", "Ontology ID")},
+		Responses: doc.R(doc.OK(doc.Ref("Ontology")), doc.NotFound()),
+	})
+	doc.Register("PUT", "/api/ontologies/{id}", doc.RouteDoc{
+		Summary:     "Update ontology",
+		Tags:        []string{"Ontologies"},
+		Params:      []doc.Param{doc.PParam("id", "Ontology ID")},
+		RequestBody: doc.JsonBody(doc.Ref("OntologyUpdateRequest")),
+		Responses:   doc.R(doc.OK(doc.Ref("Ontology")), doc.BadRequest(), doc.NotFound()),
+	})
+	doc.Register("DELETE", "/api/ontologies/{id}", doc.RouteDoc{
+		Summary:   "Delete ontology",
+		Tags:      []string{"Ontologies"},
+		Params:    []doc.Param{doc.PParam("id", "Ontology ID")},
+		Responses: doc.R(doc.NoContent(), doc.NotFound()),
+	})
+
+	// ── Extraction ─────────────────────────────────────────────────────────────
+	doc.Register("POST", "/api/extraction/generate-ontology", doc.RouteDoc{
+		Summary:     "Extract entities and generate ontology",
+		Description: "Runs the schema-inductive extraction algorithm over the specified storage backends, generates an OWL/Turtle ontology, and diffs it against existing active ontologies. If changes are detected the new ontology is flagged as 'needs_review' and the diff is returned.",
+		Tags:        []string{"Extraction"},
+		RequestBody: doc.JsonBody(doc.Ref("OntologyExtractionRequest")),
+		Responses: doc.R(doc.Created(doc.Props(nil, doc.M{
+			"ontology":           doc.Ref("Ontology"),
+			"extraction_summary": doc.Obj("Entity and relationship counts"),
+			"ontology_diff":      doc.Obj("Diff against the existing active ontology, if any"),
+		})), doc.BadRequest()),
+	})
+}

--- a/pkg/api/routes_pipelines.go
+++ b/pkg/api/routes_pipelines.go
@@ -1,0 +1,81 @@
+package api
+
+import "github.com/mimir-aip/mimir-aip-go/pkg/api/doc"
+
+func init() {
+	doc.Register("GET", "/api/pipelines", doc.RouteDoc{
+		Summary:     "List pipelines",
+		Description: "Returns all pipelines, optionally filtered by project.",
+		Tags:        []string{"Pipelines"},
+		Params:      []doc.Param{doc.QParam("project_id", "Filter by project ID", false)},
+		Responses:   doc.R(doc.OK(doc.ArrOf("Pipeline"))),
+	})
+	doc.Register("POST", "/api/pipelines", doc.RouteDoc{
+		Summary:     "Create pipeline",
+		Description: "Creates a new pipeline.",
+		Tags:        []string{"Pipelines"},
+		RequestBody: doc.JsonBody(doc.Ref("PipelineCreateRequest")),
+		Responses:   doc.R(doc.Created(doc.Ref("Pipeline")), doc.BadRequest()),
+	})
+	doc.Register("POST", "/api/pipelines/execute", doc.RouteDoc{
+		Summary:     "Execute pipeline",
+		Description: "Enqueues a pipeline for asynchronous execution by a worker.",
+		Tags:        []string{"Pipelines"},
+		RequestBody: doc.JsonBody(doc.Ref("PipelineExecutionRequest")),
+		Responses:   doc.R(doc.Created(doc.Ref("WorkTask")), doc.BadRequest()),
+	})
+	doc.Register("GET", "/api/pipelines/{id}", doc.RouteDoc{
+		Summary:     "Get pipeline",
+		Description: "Returns a single pipeline by ID.",
+		Tags:        []string{"Pipelines"},
+		Params:      []doc.Param{doc.PParam("id", "Pipeline ID")},
+		Responses:   doc.R(doc.OK(doc.Ref("Pipeline")), doc.NotFound()),
+	})
+	doc.Register("PUT", "/api/pipelines/{id}", doc.RouteDoc{
+		Summary:     "Update pipeline",
+		Description: "Updates a pipeline's description, steps, or status.",
+		Tags:        []string{"Pipelines"},
+		Params:      []doc.Param{doc.PParam("id", "Pipeline ID")},
+		RequestBody: doc.JsonBody(doc.Ref("PipelineUpdateRequest")),
+		Responses:   doc.R(doc.OK(doc.Ref("Pipeline")), doc.BadRequest(), doc.NotFound()),
+	})
+	doc.Register("DELETE", "/api/pipelines/{id}", doc.RouteDoc{
+		Summary:     "Delete pipeline",
+		Description: "Deletes a pipeline.",
+		Tags:        []string{"Pipelines"},
+		Params:      []doc.Param{doc.PParam("id", "Pipeline ID")},
+		Responses:   doc.R(doc.NoContent(), doc.NotFound()),
+	})
+
+	// ── Schedules ─────────────────────────────────────────────────────────────
+	doc.Register("GET", "/api/schedules", doc.RouteDoc{
+		Summary:   "List schedules",
+		Tags:      []string{"Schedules"},
+		Responses: doc.R(doc.OK(doc.ArrOf("Schedule"))),
+	})
+	doc.Register("POST", "/api/schedules", doc.RouteDoc{
+		Summary:     "Create schedule",
+		Tags:        []string{"Schedules"},
+		RequestBody: doc.JsonBody(doc.Ref("ScheduleCreateRequest")),
+		Responses:   doc.R(doc.Created(doc.Ref("Schedule")), doc.BadRequest()),
+	})
+	doc.Register("GET", "/api/schedules/{id}", doc.RouteDoc{
+		Summary:   "Get schedule",
+		Tags:      []string{"Schedules"},
+		Params:    []doc.Param{doc.PParam("id", "Schedule ID")},
+		Responses: doc.R(doc.OK(doc.Ref("Schedule")), doc.NotFound()),
+	})
+	doc.Register("PUT", "/api/schedules/{id}", doc.RouteDoc{
+		Summary:     "Update schedule",
+		Tags:        []string{"Schedules"},
+		Params:      []doc.Param{doc.PParam("id", "Schedule ID")},
+		RequestBody: doc.JsonBody(doc.Ref("ScheduleUpdateRequest")),
+		Responses:   doc.R(doc.OK(doc.Ref("Schedule")), doc.BadRequest(), doc.NotFound()),
+	})
+	doc.Register("DELETE", "/api/schedules/{id}", doc.RouteDoc{
+		Summary:   "Delete schedule",
+		Tags:      []string{"Schedules"},
+		Params:    []doc.Param{doc.PParam("id", "Schedule ID")},
+		Responses: doc.R(doc.NoContent(), doc.NotFound()),
+	})
+}

--- a/pkg/api/routes_plugins.go
+++ b/pkg/api/routes_plugins.go
@@ -1,0 +1,68 @@
+package api
+
+import "github.com/mimir-aip/mimir-aip-go/pkg/api/doc"
+
+func init() {
+	// ── Pipeline Plugins ──────────────────────────────────────────────────────
+	doc.Register("GET", "/api/plugins", doc.RouteDoc{
+		Summary:     "List pipeline plugins",
+		Description: "Returns all installed pipeline step plugins.",
+		Tags:        []string{"Plugins"},
+		Responses:   doc.R(doc.OK(doc.ArrOf("Plugin"))),
+	})
+	doc.Register("POST", "/api/plugins", doc.RouteDoc{
+		Summary:     "Install pipeline plugin",
+		Description: "Installs a pipeline step plugin from a Git repository. Workers clone and compile the plugin at runtime.",
+		Tags:        []string{"Plugins"},
+		RequestBody: doc.JsonBody(doc.Ref("PluginInstallRequest")),
+		Responses:   doc.R(doc.Created(doc.Ref("Plugin")), doc.BadRequest()),
+	})
+	doc.Register("GET", "/api/plugins/{name}", doc.RouteDoc{
+		Summary:   "Get pipeline plugin",
+		Tags:      []string{"Plugins"},
+		Params:    []doc.Param{doc.PParam("name", "Plugin name")},
+		Responses: doc.R(doc.OK(doc.Ref("Plugin")), doc.NotFound()),
+	})
+	doc.Register("PUT", "/api/plugins/{name}", doc.RouteDoc{
+		Summary:     "Update pipeline plugin",
+		Description: "Pulls the latest version from the plugin's repository.",
+		Tags:        []string{"Plugins"},
+		Params:      []doc.Param{doc.PParam("name", "Plugin name")},
+		RequestBody: doc.JsonBody(doc.Ref("PluginUpdateRequest")),
+		Responses:   doc.R(doc.OK(doc.Ref("Plugin")), doc.NotFound()),
+	})
+	doc.Register("DELETE", "/api/plugins/{name}", doc.RouteDoc{
+		Summary:   "Uninstall pipeline plugin",
+		Tags:      []string{"Plugins"},
+		Params:    []doc.Param{doc.PParam("name", "Plugin name")},
+		Responses: doc.R(doc.NoContent(), doc.NotFound()),
+	})
+
+	// ── Dynamic Storage Plugins ───────────────────────────────────────────────
+	doc.Register("GET", "/api/storage-plugins", doc.RouteDoc{
+		Summary:     "List storage plugins",
+		Description: "Returns all dynamically installed storage backend plugins.",
+		Tags:        []string{"Storage Plugins"},
+		Responses:   doc.R(doc.OK(doc.ArrOf("ExternalStoragePlugin"))),
+	})
+	doc.Register("POST", "/api/storage-plugins", doc.RouteDoc{
+		Summary:     "Install storage plugin",
+		Description: "Clones, compiles, and registers a custom storage backend plugin from a Git repository. The repository must export 'var Plugin' satisfying models.StoragePlugin.",
+		Tags:        []string{"Storage Plugins"},
+		RequestBody: doc.JsonBody(doc.Ref("ExternalStoragePluginInstallRequest")),
+		Responses:   doc.R(doc.Created(doc.Ref("ExternalStoragePlugin")), doc.BadRequest(), doc.Unprocessable()),
+	})
+	doc.Register("GET", "/api/storage-plugins/{name}", doc.RouteDoc{
+		Summary:   "Get storage plugin",
+		Tags:      []string{"Storage Plugins"},
+		Params:    []doc.Param{doc.PParam("name", "Plugin name")},
+		Responses: doc.R(doc.OK(doc.Ref("ExternalStoragePlugin")), doc.NotFound()),
+	})
+	doc.Register("DELETE", "/api/storage-plugins/{name}", doc.RouteDoc{
+		Summary:     "Uninstall storage plugin",
+		Description: "Removes the plugin from the registry and deletes its cached .so. Note: Go plugins cannot be unloaded from memory; an orchestrator restart is required for full removal.",
+		Tags:        []string{"Storage Plugins"},
+		Params:      []doc.Param{doc.PParam("name", "Plugin name")},
+		Responses:   doc.R(doc.NoContent(), doc.NotFound()),
+	})
+}

--- a/pkg/api/routes_projects.go
+++ b/pkg/api/routes_projects.go
@@ -1,0 +1,71 @@
+package api
+
+import "github.com/mimir-aip/mimir-aip-go/pkg/api/doc"
+
+func init() {
+	doc.Register("GET", "/api/projects", doc.RouteDoc{
+		Summary:     "List projects",
+		Description: "Returns all projects, optionally filtered by status.",
+		Tags:        []string{"Projects"},
+		Params:      []doc.Param{doc.QParam("status", "Filter by project status", false)},
+		Responses:   doc.R(doc.OK(doc.ArrOf("Project"))),
+	})
+	doc.Register("POST", "/api/projects", doc.RouteDoc{
+		Summary:     "Create project",
+		Description: "Creates a new project.",
+		Tags:        []string{"Projects"},
+		RequestBody: doc.JsonBody(doc.Ref("ProjectCreateRequest")),
+		Responses:   doc.R(doc.Created(doc.Ref("Project")), doc.BadRequest()),
+	})
+	doc.Register("POST", "/api/projects/clone", doc.RouteDoc{
+		Summary:     "Clone project",
+		Description: "Deep-clones an existing project including all its pipelines, ontologies, ML models, digital twins, and storage configurations.",
+		Tags:        []string{"Projects"},
+		RequestBody: doc.JsonBody(doc.Ref("ProjectCloneRequest")),
+		Responses:   doc.R(doc.Created(doc.Ref("Project")), doc.BadRequest(), doc.NotFound()),
+	})
+	doc.Register("GET", "/api/projects/{id}", doc.RouteDoc{
+		Summary:     "Get project",
+		Description: "Returns a single project by ID.",
+		Tags:        []string{"Projects"},
+		Params:      []doc.Param{doc.PParam("id", "Project ID")},
+		Responses:   doc.R(doc.OK(doc.Ref("Project")), doc.NotFound()),
+	})
+	doc.Register("PUT", "/api/projects/{id}", doc.RouteDoc{
+		Summary:     "Update project",
+		Description: "Updates a project's name, description, or status.",
+		Tags:        []string{"Projects"},
+		Params:      []doc.Param{doc.PParam("id", "Project ID")},
+		RequestBody: doc.JsonBody(doc.Ref("ProjectUpdateRequest")),
+		Responses:   doc.R(doc.OK(doc.Ref("Project")), doc.BadRequest(), doc.NotFound()),
+	})
+	doc.Register("DELETE", "/api/projects/{id}", doc.RouteDoc{
+		Summary:     "Delete project",
+		Description: "Deletes a project and all its components.",
+		Tags:        []string{"Projects"},
+		Params:      []doc.Param{doc.PParam("id", "Project ID")},
+		Responses:   doc.R(doc.NoContent(), doc.NotFound()),
+	})
+	doc.Register("POST", "/api/projects/{id}/{componentType}/{componentId}", doc.RouteDoc{
+		Summary:     "Add component to project",
+		Description: "Associates a pipeline, ontology, ML model, digital twin, or storage config with a project.",
+		Tags:        []string{"Projects"},
+		Params: []doc.Param{
+			doc.PParam("id", "Project ID"),
+			doc.PParam("componentType", "pipelines | ontologies | mlmodels | digitaltwins | storage"),
+			doc.PParam("componentId", "Component ID to associate"),
+		},
+		Responses: doc.R(doc.NoContent(), doc.BadRequest(), doc.NotFound()),
+	})
+	doc.Register("DELETE", "/api/projects/{id}/{componentType}/{componentId}", doc.RouteDoc{
+		Summary:     "Remove component from project",
+		Description: "Removes the association between a component and a project.",
+		Tags:        []string{"Projects"},
+		Params: []doc.Param{
+			doc.PParam("id", "Project ID"),
+			doc.PParam("componentType", "pipelines | ontologies | mlmodels | digitaltwins | storage"),
+			doc.PParam("componentId", "Component ID to disassociate"),
+		},
+		Responses: doc.R(doc.NoContent(), doc.BadRequest(), doc.NotFound()),
+	})
+}

--- a/pkg/api/routes_storage.go
+++ b/pkg/api/routes_storage.go
@@ -1,0 +1,82 @@
+package api
+
+import "github.com/mimir-aip/mimir-aip-go/pkg/api/doc"
+
+func init() {
+	// ── Storage Configs ────────────────────────────────────────────────────────
+	doc.Register("GET", "/api/storage/configs", doc.RouteDoc{
+		Summary:     "List storage configs",
+		Description: "Returns all storage configurations for a project.",
+		Tags:        []string{"Storage"},
+		Params:      []doc.Param{doc.QParam("project_id", "Filter by project ID", true)},
+		Responses:   doc.R(doc.OK(doc.ArrOf("StorageConfig"))),
+	})
+	doc.Register("POST", "/api/storage/configs", doc.RouteDoc{
+		Summary:     "Create storage config",
+		Description: "Creates a new storage backend configuration for a project.",
+		Tags:        []string{"Storage"},
+		RequestBody: doc.JsonBody(doc.Ref("StorageConfigCreateRequest")),
+		Responses:   doc.R(doc.Created(doc.Ref("StorageConfig")), doc.BadRequest()),
+	})
+	doc.Register("GET", "/api/storage/configs/{id}", doc.RouteDoc{
+		Summary:   "Get storage config",
+		Tags:      []string{"Storage"},
+		Params:    []doc.Param{doc.PParam("id", "Storage config ID")},
+		Responses: doc.R(doc.OK(doc.Ref("StorageConfig")), doc.NotFound()),
+	})
+	doc.Register("PUT", "/api/storage/configs/{id}", doc.RouteDoc{
+		Summary:     "Update storage config",
+		Tags:        []string{"Storage"},
+		Params:      []doc.Param{doc.PParam("id", "Storage config ID")},
+		RequestBody: doc.JsonBody(doc.Ref("StorageConfigUpdateRequest")),
+		Responses:   doc.R(doc.OK(doc.Ref("StorageConfig")), doc.BadRequest(), doc.NotFound()),
+	})
+	doc.Register("DELETE", "/api/storage/configs/{id}", doc.RouteDoc{
+		Summary:   "Delete storage config",
+		Tags:      []string{"Storage"},
+		Params:    []doc.Param{doc.PParam("id", "Storage config ID")},
+		Responses: doc.R(doc.NoContent(), doc.NotFound()),
+	})
+
+	// ── CIR Data Operations ────────────────────────────────────────────────────
+	doc.Register("POST", "/api/storage/store", doc.RouteDoc{
+		Summary:     "Store CIR data",
+		Description: "Writes one or more CIR records to the specified storage backend.",
+		Tags:        []string{"Storage"},
+		RequestBody: doc.JsonBody(doc.Ref("StorageStoreRequest")),
+		Responses:   doc.R(doc.OK(doc.Ref("StorageResult"))),
+	})
+	doc.Register("POST", "/api/storage/retrieve", doc.RouteDoc{
+		Summary:     "Retrieve CIR data",
+		Description: "Queries and returns CIR records from the specified storage backend.",
+		Tags:        []string{"Storage"},
+		RequestBody: doc.JsonBody(doc.Ref("StorageQueryRequest")),
+		Responses:   doc.R(doc.OK(doc.ArrOf("CIR"))),
+	})
+	doc.Register("POST", "/api/storage/update", doc.RouteDoc{
+		Summary:     "Update CIR data",
+		Description: "Applies delta updates to matching CIR records in the specified storage backend.",
+		Tags:        []string{"Storage"},
+		RequestBody: doc.JsonBody(doc.Ref("StorageUpdateRequest")),
+		Responses:   doc.R(doc.OK(doc.Ref("StorageResult"))),
+	})
+	doc.Register("POST", "/api/storage/delete", doc.RouteDoc{
+		Summary:     "Delete CIR data",
+		Description: "Deletes matching CIR records from the specified storage backend.",
+		Tags:        []string{"Storage"},
+		RequestBody: doc.JsonBody(doc.Ref("StorageDeleteRequest")),
+		Responses:   doc.R(doc.OK(doc.Ref("StorageResult"))),
+	})
+
+	// ── Storage Health ─────────────────────────────────────────────────────────
+	doc.Register("GET", "/api/storage/{id}/health", doc.RouteDoc{
+		Summary:     "Storage health check",
+		Description: "Checks connectivity to the underlying backend for the given storage config ID.",
+		Tags:        []string{"Storage"},
+		Params:      []doc.Param{doc.PParam("id", "Storage config ID")},
+		Responses: doc.R(doc.OK(doc.Props(nil, doc.M{
+			"healthy": doc.Bool("Whether the backend is reachable"),
+			"error":   doc.Str("Error message if unhealthy"),
+		}))),
+	})
+}

--- a/pkg/api/routes_system.go
+++ b/pkg/api/routes_system.go
@@ -1,0 +1,62 @@
+package api
+
+import "github.com/mimir-aip/mimir-aip-go/pkg/api/doc"
+
+func init() {
+	// ── System ────────────────────────────────────────────────────────────────
+	doc.Register("GET", "/health", doc.RouteDoc{
+		Summary:     "Health check",
+		Description: "Returns 200 when the orchestrator process is running.",
+		Tags:        []string{"System"},
+		Responses:   doc.R(doc.OK(doc.Props(nil, doc.M{"status": doc.Str("Always 'healthy'")}))),
+	})
+	doc.Register("GET", "/ready", doc.RouteDoc{
+		Summary:     "Readiness check",
+		Description: "Returns 200 when the queue is accessible and the orchestrator is ready to serve requests.",
+		Tags:        []string{"System"},
+		Responses:   doc.R(doc.OK(doc.Props(nil, doc.M{"status": doc.Str("'ready' or 'not ready'")})), doc.ServerError()),
+	})
+	doc.Register("GET", "/api/metrics", doc.RouteDoc{
+		Summary:     "Platform metrics",
+		Description: "Returns task counts by status and type, plus the current queue depth.",
+		Tags:        []string{"System"},
+		Responses:   doc.R(doc.OK(doc.Ref("MetricsResponse"))),
+	})
+
+	doc.Register("GET", "/openapi.yaml", doc.RouteDoc{
+		Summary:     "OpenAPI specification",
+		Description: "Returns the live OpenAPI 3.0 YAML specification, generated dynamically from all registered routes.",
+		Tags:        []string{"System"},
+		Responses:   doc.R(doc.OK(doc.Str("OpenAPI 3.0 YAML document"))),
+	})
+
+	// ── Work Tasks (worker-facing, requires Authorization: Bearer) ────────────
+	doc.Register("GET", "/api/worktasks", doc.RouteDoc{
+		Summary:     "Get queue info",
+		Description: "Returns the current queue depth.",
+		Tags:        []string{"Tasks"},
+		Responses:   doc.R(doc.OK(doc.Props(nil, doc.M{"queue_length": doc.Int("Number of queued tasks")}))),
+	})
+	doc.Register("POST", "/api/worktasks", doc.RouteDoc{
+		Summary:     "Submit work task",
+		Description: "Submits a new work task to the queue. Requires the worker auth token (Authorization: Bearer <token>).",
+		Tags:        []string{"Tasks"},
+		RequestBody: doc.JsonBody(doc.Ref("WorkTaskSubmissionRequest")),
+		Responses:   doc.R(doc.Created(doc.Ref("WorkTask")), doc.BadRequest()),
+	})
+	doc.Register("GET", "/api/worktasks/{id}", doc.RouteDoc{
+		Summary:     "Get work task",
+		Description: "Returns a work task by ID. Requires the worker auth token.",
+		Tags:        []string{"Tasks"},
+		Params:      []doc.Param{doc.PParam("id", "Work task ID")},
+		Responses:   doc.R(doc.OK(doc.Ref("WorkTask")), doc.NotFound()),
+	})
+	doc.Register("POST", "/api/worktasks/{id}", doc.RouteDoc{
+		Summary:     "Update work task status",
+		Description: "Called by workers to report task completion or failure. Requires the worker auth token.",
+		Tags:        []string{"Tasks"},
+		Params:      []doc.Param{doc.PParam("id", "Work task ID")},
+		RequestBody: doc.JsonBody(doc.Ref("WorkTaskResult")),
+		Responses:   doc.R(doc.OK(doc.M{"type": "object"}), doc.BadRequest(), doc.NotFound()),
+	})
+}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/mimir-aip/mimir-aip-go/pkg/api/doc"
 	"github.com/mimir-aip/mimir-aip-go/pkg/models"
 	"github.com/mimir-aip/mimir-aip-go/pkg/queue"
 	"github.com/mimir-aip/mimir-aip-go/pkg/ws"
@@ -77,6 +78,7 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("/api/worktasks/", s.workerAuthMiddleware(s.handleWorkTaskByID))
 	s.mux.HandleFunc("/api/metrics", s.handleMetrics)
 	s.mux.HandleFunc("/ws/tasks", ws.WSHandler(s.hub))
+	s.mux.HandleFunc("/openapi.yaml", s.handleOpenAPISpec)
 }
 
 // RegisterHandler adds a custom handler to the server
@@ -303,4 +305,19 @@ func (s *Server) handleWorkTaskUpdate(w http.ResponseWriter, r *http.Request, ta
 
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(map[string]string{"status": "updated"})
+}
+
+// handleOpenAPISpec serves GET /openapi.yaml — the live, auto-generated spec.
+func (s *Server) handleOpenAPISpec(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	spec, err := doc.GenerateSpec()
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Failed to generate spec: %v", err), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/yaml")
+	fmt.Fprint(w, spec)
 }


### PR DESCRIPTION
## Summary

- Replaces the hand-maintained OpenAPI generator with a route registry pattern — adding a new endpoint now automatically includes it in the spec with zero extra effort
- Each handler file has a companion `routes_*.go` with an `init()` function calling `doc.Register()`; the generator imports `_ "pkg/api"` to trigger all registrations then calls `doc.GenerateSpec()`
- Live spec served at `GET /openapi.yaml` from the running orchestrator
- CI `openapi-check` job fails if `docs/openapi.yaml` is stale

## Changes

| File(s) | Purpose |
|---------|---------|
| `pkg/api/doc/` | Registry, schema/param/response helpers, all component schemas |
| `pkg/api/routes_*.go` (8 files) | Route registrations for all 55+ endpoints |
| `cmd/openapi-gen/main.go` | 29-line generator: import + `GenerateSpec()` |
| `pkg/api/server.go` | `GET /openapi.yaml` live endpoint |
| `docs/openapi.yaml` | Generated spec (2888 lines, auto-kept in sync) |
| `docs/custom-plugins.md` | Plugin authoring guide (pipeline + storage) |
| `.github/workflows/ci.yml` | Test job + `openapi-check` enforcement job |

## Test plan

- [ ] `go test -race ./pkg/...` passes
- [ ] `go vet ./...` clean
- [ ] `go run ./cmd/openapi-gen > docs/openapi.yaml && git diff --exit-code docs/openapi.yaml` shows no diff
- [ ] Running orchestrator serves valid YAML at `GET /openapi.yaml`
- [ ] Adding a new `doc.Register()` call and re-running the generator picks it up automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)