### PR TITLE
fix: scope twin insights and authenticate stateless workers

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"math"
 	"net/http"
@@ -18,6 +19,24 @@ import (
 	"github.com/mimir-aip/mimir-aip-go/pkg/pluginruntime"
 	"github.com/mimir-aip/mimir-aip-go/pkg/plugins"
 )
+
+func getWorkerAuthToken() string {
+	return os.Getenv("WORKER_AUTH_TOKEN")
+}
+
+func doOrchestratorRequest(method, url string, body io.Reader) (*http.Response, error) {
+	req, err := http.NewRequest(method, url, body)
+	if err != nil {
+		return nil, err
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if token := getWorkerAuthToken(); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	return http.DefaultClient.Do(req)
+}
 
 func getOrchestratorURL() string {
 	if url := os.Getenv("ORCHESTRATOR_URL"); url != "" {
@@ -56,13 +75,13 @@ func main() {
 	if err != nil {
 		log.Printf("Work task execution failed: %v", err)
 		// Report failure
-		reportWorkTaskCompletion(orchestratorURL, taskID, models.WorkTaskStatusFailed, "", err.Error())
+		reportWorkTaskCompletion(orchestratorURL, taskID, models.WorkTaskStatusFailed, "", err.Error(), nil)
 		os.Exit(1)
 	}
 
 	// Report success
 	log.Printf("Work task %s completed successfully", taskID)
-	reportWorkTaskCompletion(orchestratorURL, taskID, models.WorkTaskStatusCompleted, result.OutputLocation, "")
+	reportWorkTaskCompletion(orchestratorURL, taskID, models.WorkTaskStatusCompleted, result.OutputLocation, "", result.Metadata)
 }
 
 // executeWorkTask executes the work task based on its type
@@ -77,7 +96,7 @@ func executeWorkTask(task *models.WorkTask) (*models.WorkTaskResult, error) {
 	case models.WorkTaskTypeMLInference:
 		return executeMLInference(task)
 	case models.WorkTaskTypeDigitalTwinProcessing:
-		return executeDigitalTwinUpdate(task)
+		return executeDigitalTwinProcessing(task)
 	default:
 		return nil, fmt.Errorf("unknown work task type: %s", task.Type)
 	}
@@ -1015,9 +1034,9 @@ func workerRunInference(modelType string, parameters map[string]any, features []
 	}
 }
 
-// executeDigitalTwinUpdate executes one explicit twin-processing run using only
+// executeDigitalTwinProcessing executes one explicit twin-processing run using only
 // task parameters persisted by the orchestrator. Workers remain stateless.
-func executeDigitalTwinUpdate(task *models.WorkTask) (*models.WorkTaskResult, error) {
+func executeDigitalTwinProcessing(task *models.WorkTask) (*models.WorkTaskResult, error) {
 	log.Printf("Executing digital twin processing for project: %s", task.ProjectID)
 
 	orchestratorURL := getOrchestratorURL()
@@ -1031,7 +1050,7 @@ func executeDigitalTwinUpdate(task *models.WorkTask) (*models.WorkTaskResult, er
 	}
 
 	executeURL := fmt.Sprintf("%s/api/internal/twin-runs/%s/execute", orchestratorURL, runID)
-	resp, err := http.Post(executeURL, "application/json", nil)
+	resp, err := doOrchestratorRequest(http.MethodPost, executeURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute twin processing run: %w", err)
 	}
@@ -1065,7 +1084,7 @@ func executeDigitalTwinUpdate(task *models.WorkTask) (*models.WorkTaskResult, er
 // getWorkTaskFromAPI fetches a work task from the orchestrator API
 func getWorkTaskFromAPI(orchestratorURL, taskID string) (*models.WorkTask, error) {
 	url := fmt.Sprintf("%s/api/worktasks/%s", orchestratorURL, taskID)
-	resp, err := http.Get(url)
+	resp, err := doOrchestratorRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch work task: %w", err)
 	}
@@ -1097,7 +1116,7 @@ func updateWorkTaskStatus(orchestratorURL, taskID string, status models.WorkTask
 	}
 
 	url := fmt.Sprintf("%s/api/worktasks/%s", orchestratorURL, taskID)
-	resp, err := http.Post(url, "application/json", bytes.NewBuffer(resultJSON))
+	resp, err := doOrchestratorRequest(http.MethodPost, url, bytes.NewBuffer(resultJSON))
 	if err != nil {
 		return fmt.Errorf("failed to update status: %w", err)
 	}
@@ -1110,12 +1129,13 @@ func updateWorkTaskStatus(orchestratorURL, taskID string, status models.WorkTask
 	return nil
 }
 
-// reportWorkTaskCompletion reports work task completion to the orchestrator
-func reportWorkTaskCompletion(orchestratorURL, taskID string, status models.WorkTaskStatus, outputLocation, errorMsg string) {
+// reportWorkTaskCompletion reports work task completion to the orchestrator.
+func reportWorkTaskCompletion(orchestratorURL, taskID string, status models.WorkTaskStatus, outputLocation, errorMsg string, metadata map[string]any) {
 	result := models.WorkTaskResult{
 		WorkTaskID:     taskID,
 		Status:         status,
 		OutputLocation: outputLocation,
+		Metadata:       metadata,
 		ErrorMessage:   errorMsg,
 	}
 
@@ -1126,7 +1146,7 @@ func reportWorkTaskCompletion(orchestratorURL, taskID string, status models.Work
 	}
 
 	url := fmt.Sprintf("%s/api/worktasks/%s", orchestratorURL, taskID)
-	resp, err := http.Post(url, "application/json", bytes.NewBuffer(resultJSON))
+	resp, err := doOrchestratorRequest(http.MethodPost, url, bytes.NewBuffer(resultJSON))
 	if err != nil {
 		log.Printf("Failed to report work task completion: %v", err)
 		return

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -2163,7 +2163,7 @@ function DigitalTwinsPage() {
 						<p style={{ color: 'var(--text-secondary)', margin: 0 }}>{selectedTwin.description || 'Ontology-grounded operational workspace for this project.'}</p>
 						<div style={{ display: 'flex', gap: '8px', marginTop: '12px', flexWrap: 'wrap' }}>
 							<Button label="Process Twin" onClick={() => handleProcessTwin(selectedTwin.id)} variant="secondary" />
-							<Button label="Sync Sources" onClick={() => handleSync(selectedTwin.id)} variant="secondary" />
+							<Button label="Queue Source Sync" onClick={() => handleSync(selectedTwin.id)} variant="secondary" />
 							<Button label="+ New Automation" onClick={() => setShowAutomationModal(true)} variant="secondary" />
 							<Button label="+ New Action" onClick={() => setShowActionModal(true)} variant="secondary" />
 							<Button label="Query Twin" onClick={() => setShowQueryModal(true)} variant="secondary" />
@@ -2187,6 +2187,7 @@ function DigitalTwinsPage() {
 								<div><strong>Ontology:</strong> {selectedTwin.ontology_id}</div>
 								<div><strong>Last Sync:</strong> {selectedTwin.last_sync_at ? new Date(selectedTwin.last_sync_at).toLocaleString() : 'Never'}</div>
 								<div><strong>Configured Storage Sources:</strong> {selectedTwin.config?.storage_ids?.length || 0}</div>
+								<div style={{ marginTop: '10px', color: 'var(--text-secondary)', fontSize: '0.85rem' }}>Process Twin runs the full workflow: sync scoped sources, generate insights, evaluate alert events, and trigger configured export actions. Queue Source Sync refreshes source-backed entities only.</div>
 							</div>
 							<div style={{ padding: '16px', border: '1px solid var(--border)', borderRadius: '10px' }}>
 								<h3 style={{ marginTop: 0 }}>Latest Processing Run</h3>
@@ -2235,7 +2236,7 @@ function DigitalTwinsPage() {
 						<Table columns={twinColumns} data={twins} actions={(row) => <>
 							<Button label="View" onClick={() => setSelectedTwin(row)} variant="secondary" />
 							<Button label="Process" onClick={() => handleProcessTwin(row.id)} variant="secondary" />
-							<Button label="Sync" onClick={() => handleSync(row.id)} variant="secondary" />
+							<Button label="Sync Sources" onClick={() => handleSync(row.id)} variant="secondary" />
 							<Button label="Delete" onClick={() => handleDelete(row.id)} variant="danger" />
 						</>} />
 					)}

--- a/pkg/analysis/service.go
+++ b/pkg/analysis/service.go
@@ -1,7 +1,6 @@
 package analysis
 
 import (
-	"context"
 	"fmt"
 	"math"
 	"sort"
@@ -194,12 +193,24 @@ func (s *Service) ResolverMetrics(projectID string) (map[string]any, error) {
 }
 
 func (s *Service) GenerateProjectInsights(projectID string) (*models.AnalysisRun, []*models.Insight, error) {
-	if projectID == "" {
-		return nil, nil, fmt.Errorf("project_id is required")
-	}
 	configs, err := s.storageService.GetProjectStorageConfigs(projectID)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to load project storage configs: %w", err)
+	}
+	storageIDs := make([]string, 0, len(configs))
+	for _, cfg := range configs {
+		storageIDs = append(storageIDs, cfg.ID)
+	}
+	return s.GenerateInsightsForStorageIDs(projectID, storageIDs)
+}
+
+func (s *Service) GenerateInsightsForStorageIDs(projectID string, storageIDs []string) (*models.AnalysisRun, []*models.Insight, error) {
+	if projectID == "" {
+		return nil, nil, fmt.Errorf("project_id is required")
+	}
+	configs, err := s.resolveStorageConfigs(projectID, storageIDs)
+	if err != nil {
+		return nil, nil, err
 	}
 	now := time.Now().UTC()
 	run := &models.AnalysisRun{
@@ -229,6 +240,32 @@ func (s *Service) GenerateProjectInsights(projectID string) (*models.AnalysisRun
 	return run, insights, nil
 }
 
+func (s *Service) resolveStorageConfigs(projectID string, storageIDs []string) ([]*models.StorageConfig, error) {
+	if len(storageIDs) == 0 {
+		return []*models.StorageConfig{}, nil
+	}
+	configs := make([]*models.StorageConfig, 0, len(storageIDs))
+	seen := make(map[string]struct{}, len(storageIDs))
+	for _, storageID := range storageIDs {
+		if storageID == "" {
+			continue
+		}
+		if _, ok := seen[storageID]; ok {
+			continue
+		}
+		seen[storageID] = struct{}{}
+		cfg, err := s.storageService.GetStorageConfig(storageID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load storage config %s: %w", storageID, err)
+		}
+		if cfg.ProjectID != projectID {
+			return nil, fmt.Errorf("storage config %s belongs to project %s, not %s", storageID, cfg.ProjectID, projectID)
+		}
+		configs = append(configs, cfg)
+	}
+	return configs, nil
+}
+
 func (s *Service) ListInsights(projectID, severity string, minConfidence float64) ([]*models.Insight, error) {
 	insights, err := s.store.ListInsightsByProject(projectID)
 	if err != nil {
@@ -245,33 +282,6 @@ func (s *Service) ListInsights(projectID, severity string, minConfidence float64
 		filtered = append(filtered, insight)
 	}
 	return filtered, nil
-}
-
-func (s *Service) StartInsightLoop(ctx context.Context, interval time.Duration) {
-	if interval <= 0 {
-		interval = 24 * time.Hour
-	}
-	go func() {
-		ticker := time.NewTicker(interval)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				projects, err := s.store.ListProjects()
-				if err != nil {
-					continue
-				}
-				for _, project := range projects {
-					if project.Status != models.ProjectStatusActive {
-						continue
-					}
-					_, _, _ = s.GenerateProjectInsights(project.ID)
-				}
-			}
-		}
-	}()
 }
 
 func (s *Service) adjustedLinkPolicy(projectID string) (extraction.LinkPolicy, map[string]any, error) {
@@ -495,7 +505,6 @@ func reviewFindingKey(link models.CrossSourceLink) string {
 	sort.Strings(ordered)
 	return "cross_source_link::" + strings.Join(ordered, "::")
 }
-
 
 func meanStd(values []float64) (float64, float64) {
 	if len(values) == 0 {

--- a/pkg/analysis/service_test.go
+++ b/pkg/analysis/service_test.go
@@ -239,3 +239,50 @@ func TestDecideReviewItemAppendsDecisionHistory(t *testing.T) {
 		t.Fatalf("expected reviewer and rationale to be persisted")
 	}
 }
+
+func TestGenerateInsightsForStorageIDsUsesOnlyScopedSources(t *testing.T) {
+	service, storageSvc, cleanup := setupAnalysisService(t)
+	defer cleanup()
+
+	now := time.Now().UTC().Truncate(24 * time.Hour)
+	scopedSample := make([]*models.CIR, 0)
+	for dayOffset := 4; dayOffset >= 1; dayOffset-- {
+		ts := now.AddDate(0, 0, -dayOffset)
+		scopedSample = append(scopedSample, &models.CIR{Version: models.CIRVersion, Source: models.CIRSource{Type: models.SourceTypeDatabase, URI: "db://scoped", Timestamp: ts, Format: models.DataFormatJSON}, Data: map[string]any{"event_id": dayOffset, "severity": "high", "region": "north"}})
+	}
+	for i := 0; i < 6; i++ {
+		scopedSample = append(scopedSample, &models.CIR{Version: models.CIRVersion, Source: models.CIRSource{Type: models.SourceTypeDatabase, URI: "db://scoped", Timestamp: now, Format: models.DataFormatJSON}, Data: map[string]any{"event_id": i + 10, "severity": "high", "signal": "spike"}})
+	}
+	nonScopedSample := []*models.CIR{{Version: models.CIRVersion, Source: models.CIRSource{Type: models.SourceTypeDatabase, URI: "db://other", Timestamp: now, Format: models.DataFormatJSON}, Data: map[string]any{"event_id": 999, "severity": "low"}}}
+
+	storageSvc.RegisterPlugin("scoped-sample", &testStoragePlugin{sample: scopedSample})
+	storageSvc.RegisterPlugin("other-sample", &testStoragePlugin{sample: nonScopedSample})
+	scopedCfg, err := storageSvc.CreateStorageConfig("project-insights", "scoped-sample", map[string]any{"connection_string": "mock://scoped"})
+	if err != nil {
+		t.Fatalf("failed to create scoped storage config: %v", err)
+	}
+	otherCfg, err := storageSvc.CreateStorageConfig("project-insights", "other-sample", map[string]any{"connection_string": "mock://other"})
+	if err != nil {
+		t.Fatalf("failed to create secondary storage config: %v", err)
+	}
+
+	run, insights, err := service.GenerateInsightsForStorageIDs("project-insights", []string{scopedCfg.ID})
+	if err != nil {
+		t.Fatalf("GenerateInsightsForStorageIDs returned error: %v", err)
+	}
+	if len(insights) == 0 {
+		t.Fatal("expected scoped insight generation to produce insights")
+	}
+	if len(run.SourceIDs) != 1 || run.SourceIDs[0] != scopedCfg.ID {
+		t.Fatalf("expected run to include only scoped storage id %s, got %#v", scopedCfg.ID, run.SourceIDs)
+	}
+	persisted, err := service.ListInsights("project-insights", "", 0)
+	if err != nil {
+		t.Fatalf("failed to list persisted insights: %v", err)
+	}
+	for _, insight := range persisted {
+		if insight.Evidence["storage_id"] == otherCfg.ID {
+			t.Fatalf("expected unscoped storage %s to be excluded, found in insight %#v", otherCfg.ID, insight)
+		}
+	}
+}

--- a/pkg/digitaltwin/processor.go
+++ b/pkg/digitaltwin/processor.go
@@ -160,7 +160,7 @@ func (p *Processor) ExecuteRun(runID string) (*models.TwinProcessingRun, error) 
 	markStageCompleted(run, "sync", time.Now().UTC(), nil)
 
 	markStageRunning(run, "insights", time.Now().UTC())
-	insightRun, insights, err := p.analysisService.GenerateProjectInsights(run.ProjectID)
+	insightRun, insights, err := p.analysisService.GenerateInsightsForStorageIDs(run.ProjectID, p.twinService.storageIDsForTwin(run.DigitalTwinID))
 	if err != nil {
 		return p.failRun(run, "insights", err)
 	}

--- a/pkg/digitaltwin/service.go
+++ b/pkg/digitaltwin/service.go
@@ -147,7 +147,15 @@ func (s *Service) ensureDefaultProcessingAutomation(twin *models.DigitalTwin) er
 	return nil
 }
 
-// GetDigitalTwin retrieves a digital twin by ID
+func (s *Service) storageIDsForTwin(twinID string) []string {
+	twin, err := s.store.GetDigitalTwin(twinID)
+	if err != nil || twin == nil || twin.Config == nil {
+		return nil
+	}
+	return append([]string(nil), twin.Config.StorageIDs...)
+}
+
+// GetDigitalTwin retrieves a digital twin by ID.
 func (s *Service) GetDigitalTwin(id string) (*models.DigitalTwin, error) {
 	twin, err := s.store.GetDigitalTwin(id)
 	if err != nil {


### PR DESCRIPTION
## Summary
- fix twin processing so insight generation honors the digital twin's explicit storage scope instead of all project storage configs
- make worker HTTP calls send the configured bearer token for worker-protected endpoints while keeping workers stateless
- preserve worker result metadata on completion and clarify the frontend distinction between source sync and full twin processing

## Verification
- go test ./pkg/analysis ./pkg/digitaltwin ./cmd/worker ./pkg/api ./cmd/orchestrator ./pkg/mcp ./pkg/automation ./pkg/queue
- go test ./tests/integration -run TestDoesNotExist
- npx esbuild frontend/app.js --bundle --outfile=/tmp/mimir-frontend-check.js --loader:.js=jsx